### PR TITLE
allow dots in names of required and imported files

### DIFF
--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -47,7 +47,7 @@ module.exports = function checkForExistence(context, filePath, targets) {
         // Workaround for https://github.com/substack/node-resolve/issues/78
         if (target.relative) {
             var ext = path.extname(target.name);
-            var name = ext ? target.name : target.name + ".js";
+            var name = (ext === ".js") ? target.name : target.name + ".js";
             if (exists(path.resolve(basedir, name))) {
                 continue;
             }

--- a/tests/fixtures/no-missing-require/a.config.js
+++ b/tests/fixtures/no-missing-require/a.config.js
@@ -1,0 +1,2 @@
+"use strict";
+console.log("hello!");

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -66,6 +66,20 @@ ruleTester.run("no-missing-import", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "import aConfig from './a.config';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import aConfig from './a.config.js';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
             code: "import resolve from 'resolve';",
             options: [{"publish": "*.js"}],
             env: {node: true},

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -58,6 +58,16 @@ ruleTester.run("no-missing-require", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "require('./a.config');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./a.config.js');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
             code: "require('resolve');",
             options: [{"publish": "*.js"}],
             env: {node: true}


### PR DESCRIPTION
Version 0.3.0 throws a spurious error on e.g. `require('./webpack.config')` when `./webpack.config.js` exists. This PR includes a fix and tests.