### PR TITLE
allow .json files

### DIFF
--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -46,11 +46,36 @@ module.exports = function checkForExistence(context, filePath, targets) {
 
         // Workaround for https://github.com/substack/node-resolve/issues/78
         if (target.relative) {
-            var ext = path.extname(target.name);
-            var name = (ext === ".js") ? target.name : target.name + ".js";
-            if (exists(path.resolve(basedir, name))) {
+            var targetExt = path.extname(target.name);
+            var validExts = [".js", ".json"];
+            var targetIsResolvable = false;
+            var resolved = false;
+            var j;
+
+            for (j = 0; j < validExts.length; ++j) {
+                if (targetExt === validExts[j]) {
+                    targetIsResolvable = true;
+                    break;
+                }
+            }
+
+            if (targetIsResolvable) {
+                if (exists(path.resolve(basedir, target.name))) {
+                    resolved = true;
+                }
+            } else {
+                for (j = 0; j < validExts.length; ++j) {
+                    if (exists(path.resolve(basedir, target.name + validExts[j]))) {
+                        resolved = true;
+                        break;
+                    }
+                }
+            }
+
+            if (resolved) {
                 continue;
             }
+
         } else {
             try {
                 resolve.sync(target.name, opts);

--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -47,7 +47,7 @@ module.exports = function checkForExistence(context, filePath, targets) {
         // Workaround for https://github.com/substack/node-resolve/issues/78
         if (target.relative) {
             var ext = path.extname(target.name);
-            var name = ext ? target.name : target.name + ".js";
+            var name = (ext === ".js") ? target.name : target.name + ".js";
             if (exists(path.resolve(basedir, name))) {
                 continue;
             }

--- a/tests/fixtures/no-missing-require/a.config.js
+++ b/tests/fixtures/no-missing-require/a.config.js
@@ -1,0 +1,2 @@
+"use strict";
+console.log("hello!");

--- a/tests/fixtures/no-missing-require/c.config.json
+++ b/tests/fixtures/no-missing-require/c.config.json
@@ -1,0 +1,3 @@
+{
+  "hello": "world"
+}

--- a/tests/fixtures/no-missing-require/c.json
+++ b/tests/fixtures/no-missing-require/c.json
@@ -1,0 +1,3 @@
+{
+  "hello": "world"
+}

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -80,6 +80,34 @@ ruleTester.run("no-missing-import", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "import c from './c';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import c from './c.json';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import cConfig from './c.config';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import cConfig from './c.config.json';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
             code: "import resolve from 'resolve';",
             options: [{"publish": "*.js"}],
             env: {node: true},

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -66,6 +66,20 @@ ruleTester.run("no-missing-import", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "import aConfig from './a.config';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import aConfig from './a.config.js';",
+            env: {node: true},
+            ecmaFeatures: {modules: true},
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            filename: fixture("test.js"),
             code: "import resolve from 'resolve';",
             options: [{"publish": "*.js"}],
             env: {node: true},

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -58,6 +58,16 @@ ruleTester.run("no-missing-require", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "require('./a.config');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./a.config.js');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
             code: "require('resolve');",
             options: [{"publish": "*.js"}],
             env: {node: true}

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -68,6 +68,26 @@ ruleTester.run("no-missing-require", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "require('./c');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./c.json');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./c.config');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./c.config.json');",
+            env: {node: true}
+        },
+        {
+            filename: fixture("test.js"),
             code: "require('resolve');",
             options: [{"publish": "*.js"}],
             env: {node: true}


### PR DESCRIPTION
allow `require()` calls to `.json` files.

Perhaps users could specify an array of additional extensions to attempt resolving? This would be useful when using e.g. `register.coffee` or webpack loaders.