### PR TITLE
Update: `no-unsupported-features` gets reading `engines` of `package.json` (fixes #29)

### DIFF
--- a/docs/rules/no-unsupported-features.md
+++ b/docs/rules/no-unsupported-features.md
@@ -7,7 +7,7 @@ This rule reports when you used unsupported ECMAScript 2015 features on the spec
 
 **This rule expects to be used with `"env": {"es6": true}` configuration.**
 
-This rule requires to specify a Node version always.
+This rule requires a Node version.
 For Example:
 
 ```json
@@ -23,6 +23,8 @@ This rule accepts the following version number:
 - `4`
 - `5`
 - `6`
+
+If the version was omitted, this rule would read the [engines](https://docs.npmjs.com/files/package.json#engines) field of `package.json`.
 
 The following patterns are considered problems:
 

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -10,7 +10,9 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+var semver = require("semver");
 var features = require("../util/features");
+var getPackageJson = require("../util/get-package-json");
 var getValueIfString = require("../util/get-value-if-string");
 
 //------------------------------------------------------------------------------
@@ -52,6 +54,64 @@ var PROPERTY_TEST_TARGETS = {
         "search", "split", "match", "toPrimitive", "toStringTag", "unscopables"
     ]
 };
+
+/**
+ * Gets major version of 'semver.Comparator'.
+ *
+ * @param {semver.Comparator} comparator - A comparator to get.
+ * @returns {number} The major version of the comparator.
+ */
+function parseVersion(comparator) {
+    var major = comparator.semver.major;
+    var minor = comparator.semver.minor;
+
+    if (major >= 1) {
+        return major;
+    }
+    if (minor >= 10) {
+        return parseFloat("0." + minor);
+    }
+    return 0.10;
+}
+
+/**
+ * Gets default version configuration of this rule.
+ *
+ * This finds and reads 'package.json' file, then parses 'engines.node' field.
+ * If it's nothing, this returns '0.10'.
+ *
+ * @param {string} filename - The file name of the current linting file.
+ * @returns {number} The default version configuration.
+ */
+function getDefaultVersion(filename) {
+    var info = getPackageJson(filename);
+    var nodeVersion = info && info.engines && info.engines.node;
+
+    try {
+        var range = new semver.Range(nodeVersion);
+        var comparators = Array.prototype.concat.apply([], range.set);
+        var version = comparators.reduce(
+            function(minVersion, comparator) {
+                var op = comparator.operator;
+
+                if (op === "" || op === ">" || op === ">=") {
+                    return Math.min(minVersion, parseVersion(comparator));
+                }
+                return minVersion;
+            },
+            Number.POSITIVE_INFINITY
+        );
+
+        if (Number.isFinite(version)) {
+            return version;
+        }
+    }
+    catch (err) {
+        // ignore
+    }
+
+    return 0.10;
+}
 
 /**
  * Gets values of the `ignores` option.
@@ -186,7 +246,9 @@ function getIdentifierName(node) {
 
 module.exports = function(context) {
     var sourceCode = context.getSourceCode();
-    var supportInfo = parseOptions(context.options[0] || 0.10);
+    var supportInfo = parseOptions(
+        context.options[0] || getDefaultVersion(context.getFilename())
+    );
     var hasSpecialLexicalEnvironment = checkSpecialLexicalEnvironment(context);
 
     /**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test:mocha": "istanbul cover node_modules/mocha/bin/_mocha -- tests/lib/**/*.js --reporter progress",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },
+  "engines": {
+    "node": ">=0.10"
+  },
   "peerDependencies": {
     "eslint": ">=1.10.3 <3.0.0"
   },
@@ -23,7 +26,8 @@
     "ignore": "^3.0.11",
     "minimatch": "^3.0.0",
     "object-assign": "^4.0.1",
-    "resolve": "^1.1.7"
+    "resolve": "^1.1.7",
+    "semver": "5.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",
@@ -33,8 +37,7 @@
     "mocha": "^2.3.4",
     "npm-run-all": "^1.3.2",
     "rimraf": "^2.4.4",
-    "semver": "^5.1.0",
-    "shelljs": "^0.6.0"
+    "shelljs": "^0.7.0"
   },
   "repository": {
     "type": "git",

--- a/tests/fixtures/no-unsupported-features/gte-0.12.8/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-0.12.8/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": ">=0.12.8"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/gte-4.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-4.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": ">=4.0.0"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/gte-4.4.0-lt-5.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-4.4.0-lt-5.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": ">=4.4.0 <5.0.0"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/hat-4.1.2/package.json
+++ b/tests/fixtures/no-unsupported-features/hat-4.1.2/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": "^4.1.2"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/invalid/package.json
+++ b/tests/fixtures/no-unsupported-features/invalid/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": "foo-bar"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/lt-6.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/lt-6.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "test",
+    "engines": {
+        "node": "<6.0.0"
+    }
+}

--- a/tests/fixtures/no-unsupported-features/nothing/package.json
+++ b/tests/fixtures/no-unsupported-features/nothing/package.json
@@ -1,0 +1,4 @@
+{
+    "private": true,
+    "name": "test"
+}

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -10,6 +10,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+var path = require("path");
 var semver = require("semver");
 var rule = require("../../../lib/rules/no-unsupported-features");
 var RuleTester = require("eslint").RuleTester;
@@ -93,6 +94,15 @@ function convertPattern(retv, pattern) {
     });
 
     return retv;
+}
+
+/**
+ * Makes a file path to a fixture.
+ * @param {string} name - A name.
+ * @returns {string} A file path to a fixture.
+ */
+function fixture(name) {
+    return path.resolve(__dirname, "../../fixtures/no-unsupported-features", name);
 }
 
 //------------------------------------------------------------------------------
@@ -926,4 +936,48 @@ ruleTester.run("no-unsupported-features", rule, [
         ignores: [0.10, 0.12],
         singular: true
     }
-].reduce(convertPattern, {valid: [], invalid: []}));
+].reduce(convertPattern, {
+    valid: [
+        {
+            filename: fixture("gte-4.0.0/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true}
+        },
+        {
+            filename: fixture("gte-4.4.0-lt-5.0.0/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true}
+        },
+        {
+            filename: fixture("hat-4.1.2/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true}
+        }
+    ],
+    invalid: [
+        {
+            filename: fixture("gte-0.12.8/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true},
+            errors: ["Arrow Functions are not supported yet on Node v0.12."]
+        },
+        {
+            filename: fixture("invalid/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true},
+            errors: ["Arrow Functions are not supported yet on Node v0.10."]
+        },
+        {
+            filename: fixture("lt-6.0.0/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true},
+            errors: ["Arrow Functions are not supported yet on Node v0.10."]
+        },
+        {
+            filename: fixture("nothing/a.js"),
+            code: "var a = () => 1",
+            env: {es6: true},
+            errors: ["Arrow Functions are not supported yet on Node v0.10."]
+        }
+    ]
+}));


### PR DESCRIPTION
Fixes #29.

This depends on undocumented APIs of `semver` module. So I pinned the version of `semver`.