### PR TITLE
New: add `plugin:node/recommended` config

### DIFF
--- a/conf/recommended.json
+++ b/conf/recommended.json
@@ -1,0 +1,15 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "rules": {
+       "node/no-deprecated-api": "error",
+       "node/no-missing-import": "error",
+       "node/no-missing-require": "error",
+       "node/no-unpublished-import": "error",
+       "node/no-unpublished-require": "error",
+       "node/no-unsupported-features": "error",
+       "node/shebang": "error"
+    }
+}

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -61,6 +61,9 @@ var ruleNames = ls("lib/rules").map(toBasename);
     "    },",
     "    rulesConfig: {",
     ruleNames.map(toRuleLevel).join(",\n"),
+    "    },",
+    "    configs: {",
+    "        recommended: require(\"./conf/recommended.json\")",
     "    }",
     "};",
     ""


### PR DESCRIPTION
This pull request is one of PoC for #38 .

If this is merged, we can configure .eslintrc using plugin:node/recommended.

like this

```json
{
  "extends": [
    "plugin:node/recommended"
  ],
  "parserOptions": {
    "ecmaVersion": 6
  },
  "plugins": [
    "node"
  ]
}
```

This configure equals to

```json
{
  "parserOptions": {
    "ecmaVersion": 6
  },
  "plugins": [
    "node"
  ],
  "env": {
    "node": true,
    "es6": true
  },
  "rules": {
     "node/no-deprecated-api": "error",
     "node/no-missing-import": "error",
     "node/no-missing-require": "error",
     "node/no-unpublished-import": "error",
     "node/no-unpublished-require": "error",
     "node/no-unsupported-features": ["error",{"version": 4}],
     "node/shebang": "error"
  }
}
```