### PR TITLE
recommend no-process-exit

### DIFF
--- a/conf/recommended.json
+++ b/conf/recommended.json
@@ -4,6 +4,7 @@
         "node": true
     },
     "rules": {
+       "no-process-exit": "error",
        "node/no-deprecated-api": "error",
        "node/no-missing-require": "error",
        "node/no-unpublished-require": "error",

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -4,7 +4,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-unpublished-require.js
+++ b/lib/rules/no-unpublished-require.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -4,7 +4,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/check-publish.js
+++ b/lib/util/check-publish.js
@@ -4,7 +4,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/deprecated-apis.js
+++ b/lib/util/deprecated-apis.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/exists.js
+++ b/lib/util/exists.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/features.js
+++ b/lib/util/features.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-allow-modules.js
+++ b/lib/util/get-allow-modules.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-convert-path.js
+++ b/lib/util/get-convert-path.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-import-export-targets.js
+++ b/lib/util/get-import-export-targets.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-package-json.js
+++ b/lib/util/get-package-json.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-require-targets.js
+++ b/lib/util/get-require-targets.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-try-extensions.js
+++ b/lib/util/get-try-extensions.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/get-value-if-string.js
+++ b/lib/util/get-value-if-string.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "eslint": "^3.6.0",
-    "eslint-config-mysticatea": "^6.0.0",
+    "eslint-config-mysticatea": "^7.0.0",
     "if-node-version": "^1.0.0",
     "mocha": "^3.0.2",
     "npm-run-all": "^3.1.0",

--- a/tests/lib/rules/no-deprecated-api.js
+++ b/tests/lib/rules/no-deprecated-api.js
@@ -4,7 +4,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unpublished-import.js
+++ b/tests/lib/rules/no-unpublished-import.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -3,7 +3,6 @@
  * @copyright 2016 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/shebang.js
+++ b/tests/lib/rules/shebang.js
@@ -3,7 +3,6 @@
  * @copyright 2015 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-
 "use strict"
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
See upstream PR (declined) for a complete history: https://github.com/eslint/eslint/pull/7381

It's worth re-reading the upstream recommendations in the Node.js documentation, as they highlight the problems with using `process.exit()`:
- https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_process_exit_code

> The reason this is problematic is because writes to process.stdout in Node.js are sometimes _non-blocking_ and may occur over multiple ticks of the Node.js event loop. Calling `process.exit()`, however, forces the process to exit before those additional writes to stdout can be performed.
> 
> Rather than calling `process.exit()` directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop
- https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_process_exitcode

It seems that the upstream Node.js team recommends against using this API, so it follows that ESLint should also recommend against its use.
