### PR TITLE
Fix: `no-deprecated-api` crash on undeclared assignment (fixes #55)

### DIFF
--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -246,11 +246,10 @@ module.exports = function(context) {
                 break
 
             case "Identifier":
-                checkVariable(
-                    findVariable(node, globalScope),
-                    path,
-                    infoMap
-                )
+                var variable = findVariable(node, globalScope)
+                if (variable != null) {
+                    checkVariable(variable, path, infoMap)
+                }
                 break
 
             case "ObjectPattern":

--- a/tests/lib/rules/no-deprecated-api.js
+++ b/tests/lib/rules/no-deprecated-api.js
@@ -86,6 +86,12 @@ ruleTester.run("no-deprecated-api", rule, {
             code: "import domain from 'domain';",
             parserOptions: {sourceType: "module"},
         },
+
+        // https://github.com/mysticatea/eslint-plugin-node/issues/55
+        {
+            code: "undefinedVar = require('fs')",
+            env: {node: true},
+        },
     ],
     invalid: [
         //----------------------------------------------------------------------


### PR DESCRIPTION
When assigning to a standard library module, `no-deprecated-api` stores the name of the variable that was assigned, and track references to it. However, if the variable has no declaration, it was throwing an error (see https://github.com/mysticatea/eslint-plugin-node/issues/55):

```js
foo = require('fs');
```

This fixes the issue by adding a null check to ensure that the variable has a declaration.