### PR TITLE
New Buffer APIs are available in 4.5.0

### DIFF
--- a/docs/rules/no-deprecated-api.md
+++ b/docs/rules/no-deprecated-api.md
@@ -24,7 +24,7 @@ const {exists} = require("fs");       /*ERROR: 'fs.exists' was deprecated since 
 This rule reports the following deprecated API.
 
 - buffer
-    - [Buffer constructors](https://nodejs.org/dist/v6.0.0/docs/api/buffer.html#buffer_class_buffer) (Use [safe-buffer](https://www.npmjs.com/package/safe-buffer) module for `Node@<6.0.0`)
+    - [Buffer constructors](https://nodejs.org/dist/v6.0.0/docs/api/buffer.html#buffer_class_buffer) (Use [safe-buffer](https://www.npmjs.com/package/safe-buffer) module for `Node@<4.5.0`)
     - [SlowBuffer class](https://nodejs.org/dist/v6.0.0/docs/api/buffer.html#buffer_class_slowbuffer)
 - crypto
     - [createCredentials](https://nodejs.org/dist/v0.12.0/docs/api/crypto.html#crypto_crypto_createcredentials_details)

--- a/lib/util/deprecated-apis.js
+++ b/lib/util/deprecated-apis.js
@@ -16,12 +16,12 @@ module.exports = {
                 $constructor: {
                     $deprecated: true,
                     since: 6,
-                    replacedBy: "'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0')",
+                    replacedBy: "'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0')",
                 },
                 $call: {
                     $deprecated: true,
                     since: 6,
-                    replacedBy: "'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0')",
+                    replacedBy: "'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0')",
                 },
             },
             SlowBuffer: {
@@ -266,13 +266,13 @@ module.exports = {
                 $deprecated: true,
                 global: true,
                 since: 6,
-                replacedBy: "'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0')",
+                replacedBy: "'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0')",
             },
             $call: {
                 $deprecated: true,
                 global: true,
                 since: 6,
-                replacedBy: "'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0')",
+                replacedBy: "'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0')",
             },
         },
         Intl: {

--- a/tests/lib/rules/no-deprecated-api.js
+++ b/tests/lib/rules/no-deprecated-api.js
@@ -169,60 +169,60 @@ ruleTester.run("no-deprecated-api", rule, {
         {
             code: "new (require('buffer').Buffer)()",
             env: {node: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "require('buffer').Buffer()",
             env: {node: true},
-            errors: ["'buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var b = require('buffer'); new b.Buffer()",
             env: {node: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var b = require('buffer'); new b['Buffer']()",
             env: {node: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var b = require('buffer'); new b[`Buffer`]()",
             env: {node: true, es6: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var b = require('buffer').Buffer; new b()",
             env: {node: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var b; new ((b = require('buffer')).Buffer)(); new b.Buffer()",
             env: {node: true},
             errors: [
-                "'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead.",
-                "'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead.",
+                "'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.",
+                "'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.",
             ],
         },
         {
             code: "var {Buffer: b} = require('buffer'); new b()",
             env: {node: true, es6: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var {['Buffer']: b = null} = require('buffer'); new b()",
             env: {node: true, es6: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var {'Buffer': b = null} = require('buffer'); new b()",
             env: {node: true, es6: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "var {Buffer: b = require('buffer').Buffer} = {}; new b()",
             env: {node: true, es6: true},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "require('buffer').SlowBuffer",
@@ -451,25 +451,25 @@ ruleTester.run("no-deprecated-api", rule, {
             code: "import b from 'buffer'; new b.Buffer()",
             env: {es6: true},
             parserOptions: {sourceType: "module"},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "import * as b from 'buffer'; new b.Buffer()",
             env: {es6: true},
             parserOptions: {sourceType: "module"},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "import * as b from 'buffer'; new b.default.Buffer()",
             env: {es6: true},
             parserOptions: {sourceType: "module"},
-            errors: ["'new buffer.default.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.default.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "import {Buffer as b} from 'buffer'; new b()",
             env: {es6: true},
             parserOptions: {sourceType: "module"},
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "import b from 'buffer'; b.SlowBuffer",
@@ -509,7 +509,7 @@ ruleTester.run("no-deprecated-api", rule, {
                 ignoreModuleItems: ["buffer.Buffer()"],
                 ignoreGlobalItems: ["Buffer()", "new Buffer()"],
             }],
-            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "require('buffer').Buffer()",
@@ -518,7 +518,7 @@ ruleTester.run("no-deprecated-api", rule, {
                 ignoreModuleItems: ["new buffer.Buffer()"],
                 ignoreGlobalItems: ["Buffer()", "new Buffer()"],
             }],
-            errors: ["'buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
 
         //----------------------------------------------------------------------
@@ -527,12 +527,12 @@ ruleTester.run("no-deprecated-api", rule, {
         {
             code: "new Buffer;",
             env: {node: true},
-            errors: ["'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "Buffer();",
             env: {node: true},
-            errors: ["'Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "Intl.v8BreakIterator;",
@@ -581,7 +581,7 @@ ruleTester.run("no-deprecated-api", rule, {
                 ignoreModuleItems: ["buffer.Buffer()", "new buffer.Buffer()"],
                 ignoreGlobalItems: ["Buffer()"],
             }],
-            errors: ["'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
         {
             code: "Buffer()",
@@ -590,7 +590,7 @@ ruleTester.run("no-deprecated-api", rule, {
                 ignoreModuleItems: ["buffer.Buffer()", "new buffer.Buffer()"],
                 ignoreGlobalItems: ["new Buffer()"],
             }],
-            errors: ["'Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<6.0.0') instead."],
+            errors: ["'Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead."],
         },
     ],
 })


### PR DESCRIPTION
The new Buffer APIs were backported to 4.5.0, so we should update the
error message so users who don't care about <4.5.0 can avoid using
safe-buffer.

The changelog for 4.5.0 is here: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#2016-08-15-version-450-argon-lts-thealphanerd