### PR TITLE
Fix: README etc. are only assumed published if in pkg root (fixes #73)

### DIFF
--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -77,7 +77,7 @@ function filterNeverIgnoredFiles(p) {
     return (filePath) => (
         path.join(basedir, filePath) !== mainFilePath &&
         filePath !== "package.json" &&
-        !NEVER_IGNORED.test(path.basename(filePath))
+        !NEVER_IGNORED.test(path.relative(basedir, filePath))
     )
 }
 

--- a/tests/lib/rules/no-unpublished-import.js
+++ b/tests/lib/rules/no-unpublished-import.js
@@ -121,6 +121,13 @@ ruleTester.run("no-unpublished-import", rule, {
             code: "import electron from 'electron';",
             options: [{allowModules: ["electron"]}],
         },
+
+        // Auto-published files only apply to root package directory
+        {
+            filename: fixture("3/src/readme.js"),
+            code: "import bbb from 'bbb';",
+            env: {node: true},
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -235,6 +235,13 @@ ruleTester.run("no-unpublished-require", rule, {
             options: [{allowModules: ["electron"]}],
             env: {node: true},
         },
+
+        // Auto-published files only apply to root package directory
+        {
+            filename: fixture("3/src/readme.js"),
+            code: "require('bbb');",
+            env: {node: true},
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
This implements one of the approaches I outlined in issue #73 to ensure that files like `test/readme.js` (has a basename equal to something that npm auto-publishes, but is not in the package root) are not treated as published and so can require devDependencies.

Specifically, when using the NEVER_IGNORED regex, this PR will pass the full relative path from package root to the linted file, instead of the linted file's basename. All existing tests pass with this logic, and my new tests also pass (but failed with the old logic).

Please let me know if I should make any changes.