### PR TITLE
Feat: Add option 'infer' for rule no-unsupported-features

### DIFF
--- a/docs/rules/no-unsupported-features.md
+++ b/docs/rules/no-unsupported-features.md
@@ -17,7 +17,8 @@ This rule reports when you used unsupported ECMAScript 2015-2017 features on the
 }
 ```
 
-:warning: This rule reads the [engines] field of `package.json` to detect Node.js version.
+:warning: This rule uses the [engines] field of `package.json` to detect Node.js version.
+Alternatively, the `infer` option can be used to detect the Node.js version from the process.
 
 I recommend a use of the [engines] field since it's the official way to indicate what Node.js versions your module is supporting.
 For example of `package.json`:
@@ -109,7 +110,8 @@ var p = new Promise((resolve, reject) => {
 {
     "node/no-unsupported-features": ["error", {
         "version": 4,
-        "ignores": []
+        "ignores": [],
+        "infer": false
     }]
 }
 ```
@@ -268,6 +270,23 @@ Examples of :+1: **correct** code for the `"ignores"` option:
 ```js
 /*eslint node/no-unsupported-features: ["error", {version: 4, ignores: ["defaultParameters"]}]*/
 /*eslint-env es6*/
+
+function foo(a = 1) {
+    //...
+}
+```
+
+### infer
+
+The Node.js version can be automatically detected by setting this option to `true`.
+
+Examples of :+1: **correct** code for the `"infer"` option:
+
+```js
+/*eslint node/no-unsupported-features: ["error", {infer: true}]*/
+/*eslint-env es6*/
+
+assert.equal(process.versions.node, '6.10.0');
 
 function foo(a = 1) {
     //...

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -28,6 +28,7 @@ const VERSION_MAP = new Map([
     [7.6, "7.6.0"],
     [8, "8.0.0"],
 ])
+const INFER_SCHEMA = {enum: ["infer"]}
 const VERSION_SCHEMA = {
     anyOf: [
         {enum: Array.from(VERSION_MAP.keys())},
@@ -206,12 +207,19 @@ function parseOptions(options, defaultVersion) {
         version = VERSION_MAP.get(options)
     }
     else if (typeof options === "string") {
-        version = options
+        version = options === "infer"
+            ? version = process.versions.node
+            : version = options
     }
     else if (typeof options === "object") {
-        version = (typeof options.version === "number")
-            ? VERSION_MAP.get(options.version)
-            : options.version || defaultVersion
+        if (options.infer === true) {
+            version = process.versions.node
+        }
+        else {
+            version = (typeof options.version === "number")
+                ? VERSION_MAP.get(options.version)
+                : options.version || defaultVersion
+        }
         ignores = options.ignores || []
     }
 
@@ -732,6 +740,7 @@ module.exports = {
             {
                 anyOf: [
                     VERSION_SCHEMA.anyOf[0],
+                    INFER_SCHEMA,
                     VERSION_SCHEMA.anyOf[1],
                     {
                         type: "object",
@@ -741,6 +750,9 @@ module.exports = {
                                 type: "array",
                                 items: {enum: getIgnoresEnum()},
                                 uniqueItems: true,
+                            },
+                            infer: {
+                                type: "boolean",
                             },
                         },
                         additionalProperties: false,


### PR DESCRIPTION
First off, thank you for this plugin!

This implements automatic Node.js version detection using `process.versions` through option `"infer"`. In my opinion, the `engines` field in `package.json` is appropriate for when authoring a library. For majority of cases, the node version in development environment is probably the target version as well. We can use `process.versions` to simplify configuration of this rule:

```
λ node
> process.versions
{ http_parser: '2.7.0',
  node: '8.2.1',
  v8: '5.8.283.41',
  uv: '1.13.1',
  zlib: '1.2.11',
  ares: '1.10.1-DEV',
  modules: '57',
  openssl: '1.0.2l',
  icu: '59.1',
  unicode: '9.0',
  cldr: '31.0.1',
  tz: '2017b' }
```

I have updated the docs as well. Let me know if there are any changes required. 