### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -293,6 +293,7 @@ module.exports = {
             description: "enforce either `module.exports` or `exports`",
             category: "Stylistic Issues",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/exports-style.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -566,6 +566,7 @@ module.exports = {
             description: "disallow deprecated APIs",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-deprecated-api.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-extraneous-import.js
+++ b/lib/rules/no-extraneous-import.js
@@ -53,6 +53,7 @@ module.exports = {
             description: "disallow `import` declarations of extraneous packages",
             category: "Possible Errors",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-extraneous-import.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-extraneous-require.js
+++ b/lib/rules/no-extraneous-require.js
@@ -53,6 +53,7 @@ module.exports = {
             description: "disallow `require()` expressions of extraneous packages",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-extraneous-require.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-hide-core-modules.js
+++ b/lib/rules/no-hide-core-modules.js
@@ -106,6 +106,7 @@ module.exports = {
             description: "disallow third-party modules which are hiding core modules",
             category: "Possible Errors",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-hide-core-modules.md",
         },
         deprecated: true,
         fixable: false,

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -52,6 +52,7 @@ module.exports = {
             description: "disallow `import` declarations of missing files",
             category: "Possible Errors",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-missing-import.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -52,6 +52,7 @@ module.exports = {
             description: "disallow `require()` expressions of missing files",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-missing-require.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-bin.js
+++ b/lib/rules/no-unpublished-bin.js
@@ -99,6 +99,7 @@ module.exports = {
             description: "disallow 'bin' files which are ignored by npm",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-bin.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -54,6 +54,7 @@ module.exports = {
             description: "disallow `import` declarations of private things",
             category: "Possible Errors",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-import.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-require.js
+++ b/lib/rules/no-unpublished-require.js
@@ -54,6 +54,7 @@ module.exports = {
             description: "disallow `require()` expressions of private things",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-require.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -673,6 +673,7 @@ module.exports = {
             description: "disallow unsupported ECMAScript features on the specified version",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unsupported-features.md",
         },
         fixable: false,
         schema: [

--- a/lib/rules/process-exit-as-throw.js
+++ b/lib/rules/process-exit-as-throw.js
@@ -147,6 +147,7 @@ module.exports = {
             description: "make `process.exit()` expressions the same code path as `throw`",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/process-exit-as-throw.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -146,6 +146,7 @@ module.exports = {
             description: "enforce the correct usage of shebang",
             category: "Possible Errors",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/shebang.md",
         },
         fixable: "code",
         schema: [


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.