### PR TITLE
Docs: Use link to tagged version for rule docs

### DIFF
--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -6,6 +6,12 @@
 "use strict"
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const getDocsUrl = require("../util/get-docs-url")
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -293,7 +299,7 @@ module.exports = {
             description: "enforce either `module.exports` or `exports`",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/exports-style.md",
+            url: getDocsUrl("exports-style.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const deprecatedApis = require("../util/deprecated-apis")
+const getDocsUrl = require("../util/get-docs-url")
 const getValueIfString = require("../util/get-value-if-string")
 
 //------------------------------------------------------------------------------
@@ -566,7 +567,7 @@ module.exports = {
             description: "disallow deprecated APIs",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-deprecated-api.md",
+            url: getDocsUrl("no-deprecated-api.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-extraneous-import.js
+++ b/lib/rules/no-extraneous-import.js
@@ -12,6 +12,7 @@
 const checkExtraneous = require("../util/check-extraneous")
 const getAllowModules = require("../util/get-allow-modules")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getImportTargets = require("../util/get-import-export-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 
@@ -53,7 +54,7 @@ module.exports = {
             description: "disallow `import` declarations of extraneous packages",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-extraneous-import.md",
+            url: getDocsUrl("no-extraneous-import.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-extraneous-require.js
+++ b/lib/rules/no-extraneous-require.js
@@ -12,6 +12,7 @@
 const checkExtraneous = require("../util/check-extraneous")
 const getAllowModules = require("../util/get-allow-modules")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getRequireTargets = require("../util/get-require-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 
@@ -53,7 +54,7 @@ module.exports = {
             description: "disallow `require()` expressions of extraneous packages",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-extraneous-require.md",
+            url: getDocsUrl("no-extraneous-require.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-hide-core-modules.js
+++ b/lib/rules/no-hide-core-modules.js
@@ -15,6 +15,7 @@
 
 const path = require("path")
 const resolve = require("resolve")
+const getDocsUrl = require("../util/get-docs-url")
 const getPackageJson = require("../util/get-package-json")
 const getRequireTargets = require("../util/get-require-targets")
 const getImportExportTargets = require("../util/get-import-export-targets")
@@ -106,7 +107,7 @@ module.exports = {
             description: "disallow third-party modules which are hiding core modules",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-hide-core-modules.md",
+            url: getDocsUrl("no-hide-core-modules.md"),
         },
         deprecated: true,
         fixable: false,

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -11,6 +11,7 @@
 
 const checkExistence = require("../util/check-existence")
 const getAllowModules = require("../util/get-allow-modules")
+const getDocsUrl = require("../util/get-docs-url")
 const getImportExportTargets = require("../util/get-import-export-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 const getTryExtensions = require("../util/get-try-extensions")
@@ -52,7 +53,7 @@ module.exports = {
             description: "disallow `import` declarations of missing files",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-missing-import.md",
+            url: getDocsUrl("no-missing-import.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -11,6 +11,7 @@
 
 const checkExistence = require("../util/check-existence")
 const getAllowModules = require("../util/get-allow-modules")
+const getDocsUrl = require("../util/get-docs-url")
 const getRequireTargets = require("../util/get-require-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 const getTryExtensions = require("../util/get-try-extensions")
@@ -52,7 +53,7 @@ module.exports = {
             description: "disallow `require()` expressions of missing files",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-missing-require.md",
+            url: getDocsUrl("no-missing-require.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-bin.js
+++ b/lib/rules/no-unpublished-bin.js
@@ -11,6 +11,7 @@
 
 const path = require("path")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getNpmignore = require("../util/get-npmignore")
 const getPackageJson = require("../util/get-package-json")
 
@@ -99,7 +100,7 @@ module.exports = {
             description: "disallow 'bin' files which are ignored by npm",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-bin.md",
+            url: getDocsUrl("no-unpublished-bin.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -12,6 +12,7 @@
 const checkPublish = require("../util/check-publish")
 const getAllowModules = require("../util/get-allow-modules")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getImportExportTargets = require("../util/get-import-export-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 const getTryExtensions = require("../util/get-try-extensions")
@@ -54,7 +55,7 @@ module.exports = {
             description: "disallow `import` declarations of private things",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-import.md",
+            url: getDocsUrl("no-unpublished-import.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unpublished-require.js
+++ b/lib/rules/no-unpublished-require.js
@@ -12,6 +12,7 @@
 const checkPublish = require("../util/check-publish")
 const getAllowModules = require("../util/get-allow-modules")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getRequireTargets = require("../util/get-require-targets")
 const getResolvePaths = require("../util/get-resolve-paths")
 const getTryExtensions = require("../util/get-try-extensions")
@@ -54,7 +55,7 @@ module.exports = {
             description: "disallow `require()` expressions of private things",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unpublished-require.md",
+            url: getDocsUrl("no-unpublished-require.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -11,6 +11,7 @@
 
 const semver = require("semver")
 const features = require("../util/features")
+const getDocsUrl = require("../util/get-docs-url")
 const getPackageJson = require("../util/get-package-json")
 const getValueIfString = require("../util/get-value-if-string")
 
@@ -673,7 +674,7 @@ module.exports = {
             description: "disallow unsupported ECMAScript features on the specified version",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/no-unsupported-features.md",
+            url: getDocsUrl("no-unsupported-features.md"),
         },
         fixable: false,
         schema: [

--- a/lib/rules/process-exit-as-throw.js
+++ b/lib/rules/process-exit-as-throw.js
@@ -12,6 +12,7 @@
 const CodePathAnalyzer = safeRequire("eslint/lib/code-path-analysis/code-path-analyzer")
 const CodePath = safeRequire("eslint/lib/code-path-analysis/code-path")
 const CodePathSegment = safeRequire("eslint/lib/code-path-analysis/code-path-segment")
+const getDocsUrl = require("../util/get-docs-url")
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -147,7 +148,7 @@ module.exports = {
             description: "make `process.exit()` expressions the same code path as `throw`",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/process-exit-as-throw.md",
+            url: getDocsUrl("process-exit-as-throw.md"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -11,6 +11,7 @@
 
 const path = require("path")
 const getConvertPath = require("../util/get-convert-path")
+const getDocsUrl = require("../util/get-docs-url")
 const getPackageJson = require("../util/get-package-json")
 
 //------------------------------------------------------------------------------
@@ -146,7 +147,7 @@ module.exports = {
             description: "enforce the correct usage of shebang",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-node/tree/master/docs/rules/shebang.md",
+            url: getDocsUrl("shebang.md"),
         },
         fixable: "code",
         schema: [

--- a/lib/util/get-docs-url.js
+++ b/lib/util/get-docs-url.js
@@ -1,0 +1,34 @@
+/**
+ * @author Suhas Karanth
+ * @copyright 2018 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const pkg = require("../../package")
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const REPO_URL = "https://github.com/mysticatea/eslint-plugin-node"
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * Generates the URL to documentation for the given rule name. It uses the
+ * package version to build the link to a tagged version of the
+ * documentation file.
+ *
+ * @param {string} ruleName - Name of the eslint rule
+ * @returns {string} URL to the documentation for the given rule
+ */
+module.exports = function getDocsUrl(ruleName) {
+    return `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`
+}


### PR DESCRIPTION
This adds a utility function and uses the version present in package.json for generating the URL to tagged version of the rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.

_Note: This is very similar to the PR mysticatea/eslint-plugin-eslint-comments#11, but including the same description just to be through._