### PR TITLE
failing test case for negative pattern in .npmignore

### DIFF
--- a/tests/fixtures/no-unpublished/negative-in-npmignore/.npmignore
+++ b/tests/fixtures/no-unpublished/negative-in-npmignore/.npmignore
@@ -1,0 +1,2 @@
+ignore1.js
+/tests/!(helpers)

--- a/tests/fixtures/no-unpublished/negative-in-npmignore/package.json
+++ b/tests/fixtures/no-unpublished/negative-in-npmignore/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "name": "test",
+    "version": "0.0.0",
+    "dependencies": {
+        "aaa": "0.0.0"
+    },
+    "devDependencies": {
+        "bbb": "0.0.0"
+    }
+}

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -249,6 +249,14 @@ ruleTester.run("no-unpublished-require", rule, {
             code: "require('bbb');",
             env: {node: true},
         },
+
+        // negative patterns in .npmignore
+        {
+            filename: fixture("negative-in-npmignore/tests/test.js"),
+            code: "require('./ignore1.js');",
+            env: {node: true},
+        },
+
     ],
     invalid: [
         {


### PR DESCRIPTION
Currently I'm [trying to integrate](https://github.com/ember-cli/ember-cli/pull/7585) `eslint-plugin-node` into `ember-cli` codebase. 

As far as I can see for parsing `.npmignore` files `eslint-plugin-node` uses [`ignore`](https://www.npmjs.com/package/ignore) package which follows a `.gitignore` format. The issue appears for `.npmignore` exclusion patterns like "/tests/!(helpers)" which is not a valid `.gitignore` pattern but supported by `.npmignore`.

Luckily this pattern can be re-written to something like:
```
/tests/*
/tests/*/
!/tests/helpers/
```

I'm not sure if it's really important to have this fixed. But maybe a short note in the `no-unpublished-*` docs explaining that `eslint-plugin-node` doesn't fully follow `.npmignore` format is good thing...