### PR TITLE
Breaking: deprecate safe-buffer.Buffer calls

### DIFF
--- a/lib/util/deprecated-apis.js
+++ b/lib/util/deprecated-apis.js
@@ -417,3 +417,7 @@ module.exports = {
         },
     },
 }
+
+// safe-buffer.Buffer function/constructror is just a re-export of buffer.Buffer
+// and should be deprecated likewise.
+module.exports.modules["safe-buffer"] = module.exports.modules.buffer


### PR DESCRIPTION
`safe-buffer.Buffer` function/constructor is just a re-export of `buffer.Buffer` and should be deprecated likewise.

Otherwise, using `Buffer = require('safe-buffer').Buffer` magically hides the deprecation message, which it shouldn't, as that code will actually cause runtime deprecation errors on Node.js >= 10.

In fact, ecosystem analysis shows that people do that a lot to silence `standard` linter — they see a recommendation to use `safe-buffer` in the warning, they throw in `var Buffer = require('buffer').Buffer`, the warning goes away, nothing actually changes.
Example:
 * https://github.com/webdriverio/webdriverio/commit/05cbd3167c12e4930f09ef7cf93b127ba4effae4#diff-124380949022817b90b622871837d56cR31 (a module with 548 759 downloads/month),
 * and there are more of those.

Also, even if they migrate to the new API and install `safe-buffer` for the actual polyfills, the fact that that line alone disables the deprecation message makes them overlook calls to the old API.
Examples:
 * https://github.com/maxogden/websocket-stream/commit/c9312bd24d08271687d76da0fe3c83493871cf61 (218 288 d/m, fix in https://github.com/maxogden/websocket-stream/pull/142),
 * https://github.com/node-serialport/node-serialport/commit/e8d9d2b16c664224920ce1c895199b1ce2def48c (113 138 d/m, fix in https://github.com/node-serialport/node-serialport/pull/1510),
 * https://github.com/karma-runner/karma/commit/3d94b8cf18c695104ca195334dc75ff054c74eec (3 973 193 d/m, fix in https://github.com/karma-runner/karma/pull/2947),
 * and there are more of those.

Old Buffer API is going to be runtime-deprecated in Node.js 10.0 (https://github.com/nodejs/node/issues/19079) and `require('safe-buffer').Buffer(arg)` actually hits that deprecated API, so this change is needed for developers to spot those issues that would soon become runtime warnings, in advance. `eslint-plugin-node` was already helping developers to spot that deprecated Buffer API usage in advance, but only until they put `Buffer = require('safe-buffer').Buffer` into their code (and they do that a lot, since that's the recommended way to keep older Node.js versions support).

Actually, I am not even sure if this should be a breaking or a bugfix change. Thoughts?

/cc @Trott, @feross .