### PR TITLE
Chore: shorter recommended configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ $ npm install --save-dev eslint eslint-plugin-node
 
 ```json
 {
-    "plugins": ["node"],
     "extends": ["eslint:recommended", "plugin:node/recommended"],
     "rules": {
         "node/exports-style": ["error", "module.exports"]

--- a/lib/recommended.json
+++ b/lib/recommended.json
@@ -10,6 +10,9 @@
         "Atomics": false,
         "SharedArrayBuffer": false
     },
+    "plugins": [
+        "node"
+    ],
     "rules": {
         "no-process-exit": "error",
         "node/exports-style": "off",


### PR DESCRIPTION
We do not need to write `plugins: ["node"]` when using recommended configuration.

Inspired by <https://github.com/mysticatea/eslint-plugin-eslint-comments>.