### PR TITLE
Update README.md with .eslintrc.json plugin field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ npm install --save-dev eslint eslint-plugin-node
 
 ```json
 {
+    "plugins": ["node"],
     "extends": ["eslint:recommended", "plugin:node/recommended"],
     "rules": {
         "node/exports-style": ["error", "module.exports"]


### PR DESCRIPTION
.eslintrc.json example found on [npm](https://www.npmjs.com/package/eslint-plugin-node#-install--usage) contains an additional field named plugins which can't be found in the README.md.

Without it, I'm getting the following errors:
```
  1:1  error  Definition for rule 'node/no-extraneous-require' was not found    node/no-extraneous-require
  1:1  error  Definition for rule 'node/no-missing-require' was not found       node/no-missing-require
  1:1  error  Definition for rule 'node/no-unpublished-bin' was not found       node/no-unpublished-bin
  1:1  error  Definition for rule 'node/no-unpublished-require' was not found   node/no-unpublished-require
  1:1  error  Definition for rule 'node/no-unsupported-features' was not found  node/no-unsupported-features
  1:1  error  Definition for rule 'node/process-exit-as-throw' was not found    node/process-exit-as-throw
  1:1  error  Definition for rule 'node/shebang' was not found                  node/shebang
```

The plugin field was proposed to be deleted in #113 and deleted in 9425f68c2eb5c8bd00a38416d4e05010e401951b.

I''ve tried switching from node 10 to node 8 and replacing yarn with npm. I've also tried switching from .eslintrc.js to .eslintrc.json. I'm using macOS 10.13.4

Adding ```"plugins": ["node"],``` fixed it. I can't spend more time investigating other scenarios. Am I doing something wrong? 🤔

My package.json looks like this

```
"eslint": "^4.19.1",
"eslint-config-prettier": "^2.9.0",
"eslint-plugin-jest": "^21.15.1",
"eslint-plugin-node": "^6.0.1",
"eslint-plugin-prettier": "^2.6.0",
"jest": "^22.4.3",
"prettier": "^1.12.1"
```

My .eslintrc.js looks like this

```javascript
module.exports = {
  "env": {
    "es6": true,
    "node": true,
    "jest": true
  },
  "extends": [
    "eslint:recommended",
    "plugin:prettier/recommended",
    "plugin:jest/recommended",
    "plugin:node/recommended"
  ]
};
```