### PR TITLE
Fix: update ecmaVersion 8 to 2018 in recommended configuration

### DIFF
--- a/scripts/update.js
+++ b/scripts/update.js
@@ -61,7 +61,7 @@ ${ruleNames
 `
 
 const recommendedConf = {
-    parserOptions: { ecmaVersion: 8 },
+    parserOptions: { ecmaVersion: 2018 },
     env: {
         es6: true,
         node: true,


### PR DESCRIPTION
Hi!

This PR fixes `{ecmaVersion: 8}` to `{ecmaVersion: 2018}`, which is different from the latest [README](https://github.com/mysticatea/eslint-plugin-node/blob/019ddd34ea918354200fe1752df2c6e81d05f221/README.md#L85).

Thanks.
