### PR TITLE
Breadking: update the default node version v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ npm install --save-dev eslint eslint-plugin-node
     "name": "your-module",
     "version": "1.0.0",
     "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6.0.0"
     }
 }
 ```

--- a/docs/rules/no-unsupported-features.md
+++ b/docs/rules/no-unsupported-features.md
@@ -32,7 +32,7 @@ For example of `package.json`:
 }
 ```
 
-If the [engines] field is omitted, this rule chooses `4` since it's the minimum version the community is maintaining.
+If the [engines] field is omitted, this rule chooses `6` since it's the minimum version the community is maintaining.
 
 Examples of :-1: **incorrect** code for this rule:
 

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -32,7 +32,7 @@ const VERSION_SCHEMA = {
         },
     ],
 }
-const DEFAULT_VERSION = "4.0.0"
+const DEFAULT_VERSION = "6.0.0"
 const OPTIONS = Object.keys(features)
 const FUNC_TYPE = /^(?:Arrow)?Function(?:Declaration|Expression)$/
 const CLASS_TYPE = /^Class(?:Declaration|Expression)$/

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -1373,7 +1373,7 @@ ruleTester.run(
                 parserOptions: { ecmaVersion: 2017 },
                 env: { es6: true },
                 errors: [
-                    "Trailing commas in functions are not supported yet on Node 4.0.0.",
+                    "Trailing commas in functions are not supported yet on Node 6.0.0.",
                 ],
             },
             {
@@ -1391,7 +1391,7 @@ ruleTester.run(
                 parserOptions: { ecmaVersion: 2017 },
                 env: { es6: true },
                 errors: [
-                    "Trailing commas in functions are not supported yet on Node 4.0.0.",
+                    "Trailing commas in functions are not supported yet on Node 6.0.0.",
                 ],
             },
             {


### PR DESCRIPTION
`no-unsupported-features` has a default Node version if engines field in package.json is omitted.
This PR updates the version from v4 to v6 because Node no longer supports v4.

https://github.com/nodejs/Release#release-schedule

Thanks!