### PR TITLE
Docs: add deprecated rules table (fixes #129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These rules have been deprecated in accordance with the [deprecation policy](htt
 
 | Deprecated rule | Replaced by |    |
 |:--------|:------------|:--:|
-| [node/no-unsupported-features](./docs/rules/no-unsupported-features.md) | [node/no-unsupported-ecma-features](./docs/rules/no-unsupported-ecma-features.md) |   |
+| [node/no-unsupported-features](./docs/rules/no-unsupported-features.md) | [node/no-unsupported-ecma-features](./docs/rules/no-unsupported-features/no-unsupported-ecma-features.md) |   |
 
 ## 🔧 Configs
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ $ npm install --save-dev eslint eslint-plugin-node
 
 <!--RULES_TABLE_END-->
 
+### Deprecated
+These rules have been deprecated in accordance with the [deprecation policy](https://eslint.org/docs/user-guide/rule-deprecation), and replaced by newer rules:
+
+| Deprecated rule | Replaced by |    |
+|:--------|:------------|:--:|
+| [node/no-unsupported-features](./docs/rules/no-unsupported-features.md) | [node/no-unsupported-ecma-features](./docs/rules/no-unsupported-ecma-features.md) |   |
+
 ## 🔧 Configs
 
 This plugin provides `plugin:node/recommended` preset config.


### PR DESCRIPTION
no-unsupported-features was replaced by no-unsupported-ecma-features.

I noticed the the rule tables was auto-gened. a better way is to update the build script.