### PR TITLE
Typos in function names has been fixed.

### DIFF
--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -999,7 +999,7 @@ function parseOptions(options, defaultVersion) {
  * @param {Node} node The AST node.
  * @returns {Scope} The scope that the node belongs to.
  */
-function nomalizeScope(initialScope, node) {
+function normalizeScope(initialScope, node) {
     let scope = getInnermostScope(initialScope, node)
 
     while (scope && scope.block === node) {
@@ -1169,7 +1169,7 @@ module.exports = {
                         version,
                     },
                 })
-            } else if (!nomalizeScope(context.getScope(), node).isStrict) {
+            } else if (!normalizeScope(context.getScope(), node).isStrict) {
                 context.report({
                     node,
                     message:

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -372,7 +372,7 @@ function parseOptions(context) {
  * @param {Node} node The AST node.
  * @returns {Scope} The scope that the node belongs to.
  */
-function nomalizeScope(initialScope, node) {
+function normalizeScope(initialScope, node) {
     let scope = getInnermostScope(initialScope, node)
 
     while (scope && scope.block === node) {
@@ -426,7 +426,7 @@ function dispatch(handlers, node) {
 function defineVisitor(context, options) {
     const testInfoPrototype = {
         get isStrict() {
-            return nomalizeScope(context.getScope(), this.node).isStrict
+            return normalizeScope(context.getScope(), this.node).isStrict
         },
     }
 


### PR DESCRIPTION
Just a typo-fix PR. ('nomalizeScope' -> 'normalizeScope')