### PR TITLE
Add pnp resolver

### DIFF
--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -6,6 +6,14 @@
 
 const path = require("path")
 const resolve = require("resolve")
+let pnpApi = false
+
+try {
+    // eslint-disable-next-line @mysticatea/node/no-missing-require
+    pnpApi = require("pnpapi")
+} catch (_err) {
+    pnpApi = false
+}
 
 /**
  * Resolve the given id to file paths.
@@ -17,7 +25,9 @@ const resolve = require("resolve")
  */
 function getFilePath(isModule, id, options) {
     try {
-        return resolve.sync(id, options)
+        return pnpApi && isModule
+            ? pnpApi.resolveRequest(id, options.basedir)
+            : resolve.sync(id, options)
     } catch (_err) {
         if (isModule) {
             return null


### PR DESCRIPTION
Usually `resolve` plugin does a good job, but especially with the yarn v2 version workspaces might get nested and complicated and this ensures there wouldn't be an issue for these edge cases. In my personal case, this fixed around 4/5 false reports.