### PR TITLE
no-unsupported-features/node-builtins: Add supported version for worker_threads

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -230,7 +230,7 @@ const trackMap = {
             compileFunction: { [READ]: { supported: "10.10.0" } },
         },
         worker_threads: {
-            [READ]: { supported: null, experimental: "10.5.0" },
+            [READ]: { supported: "12.11.0", experimental: "10.5.0" },
         },
     },
 }

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -4914,6 +4914,14 @@ new RuleTester({
                         { version: "10.4.99", ignores: ["worker_threads"] },
                     ],
                 },
+                {
+                    code: "require('worker_threads')",
+                    options: [{ version: "12.11.0" }],
+                },
+                {
+                    code: "import worker_threads from 'worker_threads'",
+                    options: [{ version: "12.11.0" }],
+                },
             ],
             invalid: [
                 {
@@ -4924,7 +4932,7 @@ new RuleTester({
                             messageId: "unsupported",
                             data: {
                                 name: "worker_threads",
-                                supported: "???",
+                                supported: "12.11.0",
                                 version: "10.5.0",
                             },
                         },
@@ -4938,7 +4946,7 @@ new RuleTester({
                             messageId: "unsupported",
                             data: {
                                 name: "worker_threads",
-                                supported: "???",
+                                supported: "12.11.0",
                                 version: "10.5.0",
                             },
                         },
@@ -4952,7 +4960,7 @@ new RuleTester({
                             messageId: "unsupported",
                             data: {
                                 name: "worker_threads",
-                                supported: "???",
+                                supported: "12.11.0",
                                 version: "10.5.0",
                             },
                         },


### PR DESCRIPTION
The `worker_threads` module was declared stable in Node v12.11.0: https://nodejs.org/en/blog/release/v12.11.0/
