### PR TITLE
update node/no-unsupported-features/es-builtins to recognize fs.opendir

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -127,6 +127,8 @@ const trackMap = {
             copyFileSync: { [READ]: { supported: "8.5.0" } },
             mkdtemp: { [READ]: { supported: "5.10.0" } },
             mkdtempSync: { [READ]: { supported: "5.10.0" } },
+            opendir: { [READ]: { supported: "12.12.0" } },
+            opendirSync: { [READ]: { supported: "12.12.0" } },
             realpath: {
                 native: { [READ]: { supported: "9.2.0" } },
             },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -2346,6 +2346,14 @@ new RuleTester({
                     options: [{ version: "5.10.0" }],
                 },
                 {
+                    code: "require('fs').opendir",
+                    options: [{ version: "12.12.0" }],
+                },
+                {
+                    code: "require('fs').opendirSync",
+                    options: [{ version: "12.12.0" }],
+                },
+                {
                     code: "require('fs').realpath.native",
                     options: [{ version: "9.2.0" }],
                 },
@@ -2534,6 +2542,34 @@ new RuleTester({
                                 name: "fs.mkdtempSync",
                                 supported: "5.10.0",
                                 version: "5.9.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "require('fs').opendir",
+                    options: [{ version: "12.11.9" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "fs.opendir",
+                                supported: "12.12.0",
+                                version: "12.11.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "require('fs').opendirSync",
+                    options: [{ version: "12.11.9" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "fs.opendirSync",
+                                supported: "12.12.0",
+                                version: "12.11.9",
                             },
                         },
                     ],


### PR DESCRIPTION
`fs.opendir` and `fs.opendirSync` were added in Node v12.12.0.

- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2019-10-11-version-12120-current-bridgear
- https://nodejs.org/api/fs.html#fs_fs_opendir_path_options_callback