### PR TITLE
Update: Add onlyRelativePath option to `no-missing-require` (fixes #100)

### DIFF
--- a/docs/rules/no-missing-require.md
+++ b/docs/rules/no-missing-require.md
@@ -42,7 +42,8 @@ var foo = require(FOO_NAME);
         "node/no-missing-require": ["error", {
             "allowModules": [],
             "resolvePaths": ["/path/to/a/modules/directory"],
-            "tryExtensions": [".js", ".json", ".node"]
+            "tryExtensions": [".js", ".json", ".node"],
+            "onlyRelativePath": true
         }]
     }
 }
@@ -79,6 +80,12 @@ When an import path does not exist, this rule checks whether or not any of `path
 `tryExtensions` option is the extension list this rule uses at the time.
 
 Default is `[".js", ".json", ".node"]`.
+
+#### onlyRelativePath
+
+Checks only relative path.
+
+Default is `false`
 
 ### Shared Settings
 

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -29,6 +29,10 @@ module.exports = {
                     allowModules: getAllowModules.schema,
                     tryExtensions: getTryExtensions.schema,
                     resolvePaths: getResolvePaths.schema,
+                    onlyRelativePath: {
+                        type: "boolean",
+                        default: false,
+                    },
                 },
                 additionalProperties: false,
             },

--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -19,9 +19,15 @@ const getAllowModules = require("./get-allow-modules")
  */
 module.exports = function checkForExistence(context, targets) {
     const allowed = new Set(getAllowModules(context))
+    const onlyRelativePath =
+        (context.options &&
+            context.options[0] &&
+            context.options[0].onlyRelativePath) ||
+        false
 
     for (const target of targets) {
         const missingModule =
+            !onlyRelativePath &&
             target.moduleName != null &&
             !allowed.has(target.moduleName) &&
             target.filePath == null

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -216,6 +216,20 @@ ruleTester.run("no-missing-require", rule, {
             code: "require.resolve('eslint');",
             env: { node: true },
         },
+
+        // onlyRelativePath option
+        {
+            filename: fixture("test.js"),
+            code: "require('no-exist-package-0');",
+            options: [{ onlyRelativePath: true }],
+            env: { node: true },
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('./a.js');",
+            options: [{ onlyRelativePath: true }],
+            env: { node: true },
+        },
     ],
     invalid: [
         {
@@ -291,6 +305,15 @@ ruleTester.run("no-missing-require", rule, {
             code: "require.resolve('no-exist-package-0');",
             env: { node: true },
             errors: ['"no-exist-package-0" is not found.'],
+        },
+
+        // onlyRelativePath option
+        {
+            filename: fixture("test.js"),
+            code: "require('./c');",
+            options: [{ onlyRelativePath: true }],
+            env: { node: true },
+            errors: ['"./c" is not found.'],
         },
     ],
 })


### PR DESCRIPTION
Hi, I added `onlyRelativePath` option as discussed in [eslint-plugin-node/#100](https://github.com/mysticatea/eslint-plugin-node/issues/100)

It's my first PR, so please let me know if I missed anything. 😊