### PR TITLE
💥Update node/no-unsupported-features/node-builtins to recognize new async_hooks features

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -35,6 +35,9 @@ const trackMap = {
         async_hooks: {
             [READ]: { supported: "8.0.0" },
             createHook: { [READ]: { supported: "8.1.0" } },
+            AsyncLocalStorage: {
+                [READ]: { supported: "13.10.0", backported: ["12.17.0"] },
+            },
         },
         buffer: {
             Buffer: {

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -434,6 +434,26 @@ new RuleTester({
                         "import { createHook } from 'async_hooks'; createHook()",
                     options: [{ version: "8.1.0" }],
                 },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [{ version: "13.10.0" }],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [{ version: "13.10.0" }],
+                },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [{ version: "12.17.0" }],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [{ version: "12.17.0" }],
+                },
 
                 // Ignores
                 {
@@ -499,6 +519,46 @@ new RuleTester({
                         {
                             version: "8.0.9",
                             ignores: ["async_hooks.createHook"],
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [
+                        {
+                            version: "13.9.0",
+                            ignores: ["async_hooks.AsyncLocalStorage"],
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [
+                        {
+                            version: "13.9.0",
+                            ignores: ["async_hooks.AsyncLocalStorage"],
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [
+                        {
+                            version: "12.16.0",
+                            ignores: ["async_hooks.AsyncLocalStorage"],
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [
+                        {
+                            version: "12.16.0",
+                            ignores: ["async_hooks.AsyncLocalStorage"],
                         },
                     ],
                 },
@@ -624,6 +684,66 @@ new RuleTester({
                                 name: "async_hooks.createHook",
                                 supported: "8.1.0",
                                 version: "8.0.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [{ version: "13.9.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "async_hooks.AsyncLocalStorage",
+                                supported: "13.10.0 (backported: ^12.17.0)",
+                                version: "13.9.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [{ version: "13.9.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "async_hooks.AsyncLocalStorage",
+                                supported: "13.10.0 (backported: ^12.17.0)",
+                                version: "13.9.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "const { AsyncLocalStorage } = require('async_hooks'); new AsyncLocalStorage();",
+                    options: [{ version: "12.16.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "async_hooks.AsyncLocalStorage",
+                                supported: "13.10.0 (backported: ^12.17.0)",
+                                version: "12.16.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "import hooks from 'async_hooks'; new hooks.AsyncLocalStorage();",
+                    options: [{ version: "12.16.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "async_hooks.AsyncLocalStorage",
+                                supported: "13.10.0 (backported: ^12.17.0)",
+                                version: "12.16.0",
                             },
                         },
                     ],


### PR DESCRIPTION
Update node/no-unsupported-feature/node-builtins

- [`async_hooks.AsyncLocalStorage`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage)