### PR TITLE
💥Update node/no-unsupported-features/node-builtins to recognize new buffer features

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -46,6 +46,7 @@ const trackMap = {
             kMaxLength: { [READ]: { supported: "3.0.0" } },
             transcode: { [READ]: { supported: "7.1.0" } },
             constants: { [READ]: { supported: "8.2.0" } },
+            Blob: { [READ]: { supported: null, experimental: "15.7.0" } },
         },
         child_process: {
             ChildProcess: { [READ]: { supported: "2.2.0" } },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -795,6 +795,14 @@ new RuleTester({
                         { version: "7.0.9", ignores: ["buffer.transcode"] },
                     ],
                 },
+                {
+                    code: "const { Blob } = require('buffer'); new Blob();",
+                    options: [{ version: "15.7.0", ignores: ["buffer.Blob"] }],
+                },
+                {
+                    code: "import buffer from 'buffer'; new buffer.Blob();",
+                    options: [{ version: "15.7.0", ignores: ["buffer.Blob"] }],
+                },
             ],
             invalid: [
                 {
@@ -1004,6 +1012,34 @@ new RuleTester({
                                 name: "buffer.transcode",
                                 supported: "7.1.0",
                                 version: "7.0.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "const { Blob } = require('buffer'); new Blob();",
+                    options: [{ version: "15.7.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "buffer.Blob",
+                                supported: "(none yet)",
+                                version: "15.7.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "import buffer from 'buffer'; new buffer.Blob();",
+                    options: [{ version: "15.7.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "buffer.Blob",
+                                supported: "(none yet)",
+                                version: "15.7.0",
                             },
                         },
                     ],


### PR DESCRIPTION
Add experimental [`buffer.Blob`](https://nodejs.org/api/buffer.html#buffer_class_blob).