### PR TITLE
💥Update node/no-unsupported-features/node-builtins to recognize new assert features

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -31,6 +31,9 @@ const trackMap = {
             doesNotReject: { [READ]: { supported: "10.0.0" } },
             notDeepStrictEqual: { [READ]: { supported: "4.0.0" } },
             rejects: { [READ]: { supported: "10.0.0" } },
+            CallTracker: {
+                [READ]: { supported: null, experimental: "14.2.0" },
+            },
         },
         async_hooks: {
             [READ]: { supported: "8.0.0" },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -212,6 +212,20 @@ new RuleTester({
                         },
                     ],
                 },
+                {
+                    code:
+                        "const { CallTracker } = require('assert'); new CallTracker();",
+                    options: [
+                        { version: "14.2.0", ignores: ["assert.CallTracker"] },
+                    ],
+                },
+                {
+                    code:
+                        "import { CallTracker } from 'assert'; new CallTracker();",
+                    options: [
+                        { version: "14.2.0", ignores: ["assert.CallTracker"] },
+                    ],
+                },
             ],
             invalid: [
                 {
@@ -391,6 +405,36 @@ new RuleTester({
                                 name: "assert.strict.rejects",
                                 supported: "10.0.0",
                                 version: "9.8.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "const { CallTracker } = require('assert'); new CallTracker();",
+                    options: [{ version: "14.2.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "assert.CallTracker",
+                                supported: "(none yet)",
+                                version: "14.2.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code:
+                        "import { CallTracker } from 'assert'; new CallTracker();",
+                    options: [{ version: "14.2.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "assert.CallTracker",
+                                supported: "(none yet)",
+                                version: "14.2.0",
                             },
                         },
                     ],


### PR DESCRIPTION
- experimental [`assert.CallTracker`](https://nodejs.org/api/assert.html#assert_new_assert_calltracker)
