### PR TITLE
💥 update node/no-unsupported-features/es-builtins rule to recognize optional chaining and nullish coalescing operators

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -383,6 +383,24 @@ const features = {
             },
         ],
     },
+    optionalChaining: {
+        ruleId: "no-optional-chaining",
+        cases: [
+            {
+                supported: "14.0.0",
+                messageId: "no-optional-chaining",
+            },
+        ],
+    },
+    nullishCoalescingOperators: {
+        ruleId: "no-nullish-coalescing-operators",
+        cases: [
+            {
+                supported: "14.0.0",
+                messageId: "no-nullish-coalescing-operators",
+            },
+        ],
+    },
 }
 const keywords = Object.keys(features)
 
@@ -629,6 +647,10 @@ module.exports = {
                 "Bigint literal property names are not supported yet.",
             "no-dynamic-import":
                 "'import()' expressions are not supported yet.",
+            "no-optional-chaining":
+                "Optional chainings are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+            "no-nullish-coalescing-operators":
+                "Nullish coalescing operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
         },
     },
     create(context) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint": ">=5.16.0"
   },
   "dependencies": {
-    "eslint-plugin-es": "^3.0.0",
+    "eslint-plugin-es": "^4.1.0",
     "eslint-utils": "^2.0.0",
     "ignore": "^5.1.1",
     "minimatch": "^3.0.4",

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -2512,6 +2512,56 @@ ruleTester.run(
                 },
             ],
         },
+        {
+            keyword: "optionalChaining",
+            requiredEcmaVersion: 2020,
+            valid: [
+                {
+                    code: "foo?.bar;",
+                    options: [{ version: "14.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "foo?.bar",
+                    options: [{ version: "13.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-optional-chaining",
+                            data: {
+                                supported: "14.0.0",
+                                version: "13.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "nullishCoalescingOperators",
+            requiredEcmaVersion: 2020,
+            valid: [
+                {
+                    code: "foo ?? bar;",
+                    options: [{ version: "14.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "foo ?? bar",
+                    options: [{ version: "13.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-nullish-coalescing-operators",
+                            data: {
+                                supported: "14.0.0",
+                                version: "13.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
 
         //----------------------------------------------------------------------
         // MISC


### PR DESCRIPTION
Fixes #267
Fixes #266 