### PR TITLE
fix: support package.json private directive

### DIFF
--- a/lib/util/check-publish.js
+++ b/lib/util/check-publish.js
@@ -46,7 +46,7 @@ module.exports = function checkForPublish(context, filePath, targets) {
         )
     )
 
-    if (!npmignore.match(toRelative(filePath))) {
+    if (!npmignore.match(toRelative(filePath)) && !packageInfo.private) {
         // This file is published, so this cannot import private files.
         for (const target of targets) {
             const isPrivateFile =


### PR DESCRIPTION
Prior to this, `eslint-plugin-node` would raise a `no-unpublished-*` if a file
was not published, even if the package itself was set to private. This PR fixes
that by making `util/check-publish` respect the `private` directive in
`package.json`.
