### PR TITLE
use is-core-module@^2.3.0 to support node: scheme

### DIFF
--- a/lib/util/visit-import.js
+++ b/lib/util/visit-import.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const resolve = require("resolve")
+const isCoreModule = require("is-core-module")
 const getResolvePaths = require("./get-resolve-paths")
 const getTryExtensions = require("./get-try-extensions")
 const ImportTarget = require("./import-target")
@@ -53,7 +53,8 @@ module.exports = function visitImport(
             }
 
             const name = sourceNode && stripImportPathParams(sourceNode.value)
-            if (name && (includeCore || !resolve.isCore(name))) {
+            // Note: "999" arbitrary to check current/future Node.js version
+            if (name && (includeCore || !isCoreModule(name, "999"))) {
                 targets.push(new ImportTarget(sourceNode, name, options))
             }
         },

--- a/lib/util/visit-require.js
+++ b/lib/util/visit-require.js
@@ -6,7 +6,7 @@
 
 const path = require("path")
 const { CALL, ReferenceTracker, getStringIfConstant } = require("eslint-utils")
-const resolve = require("resolve")
+const isCoreModule = require("is-core-module")
 const getResolvePaths = require("./get-resolve-paths")
 const getTryExtensions = require("./get-try-extensions")
 const ImportTarget = require("./import-target")
@@ -48,7 +48,8 @@ module.exports = function visitRequire(
                 const targetNode = node.arguments[0]
                 const rawName = getStringIfConstant(targetNode)
                 const name = rawName && stripImportPathParams(rawName)
-                if (name && (includeCore || !resolve.isCore(name))) {
+                // Note: "999" arbitrary to check current/future Node.js version
+                if (name && (includeCore || !isCoreModule(name, "999"))) {
                     targets.push(new ImportTarget(targetNode, name, options))
                 }
             }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-es": "^4.1.0",
     "eslint-utils": "^2.0.0",
     "ignore": "^5.1.1",
+    "is-core-module": "^2.3.0",
     "minimatch": "^3.0.4",
     "resolve": "^1.10.1",
     "semver": "^6.1.0"

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -49,6 +49,10 @@ ruleTester.run("no-missing-import", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "import fs from 'node:fs';",
+        },
+        {
+            filename: fixture("test.js"),
             code: "import eslint from 'eslint/lib/api';",
         },
         {

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -27,6 +27,11 @@ ruleTester.run("no-missing-require", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "require('node:fs');",
+            env: { node: true },
+        },
+        {
+            filename: fixture("test.js"),
             code: "require('eslint');",
             env: { node: true },
         },


### PR DESCRIPTION
As requested in #275, recognize Node.js core modules referenced using the [node:](https://nodejs.org/api/esm.html#esm_node_imports) URL scheme.

Since `resolve.isCore` was moved to `is-core-module` in https://github.com/browserify/resolve/commit/7c26483576f7a44573ddc61cd5d51519deb674c5 and `is-core-module@2.3.0` added support for `node:` in https://github.com/inspect-js/is-core-module/commit/73412230a769f6e81c05eea50b6520cebf54ed2f require `is-core-module@^2.3.0`.

**Note:** `is-core-module` checks whether the module is supported in a given Node.js version (if not provided, the current version is checked).  Although checking whether a name is a core module in all Node.js versions supported by the package would be ideal, it will require significantly more design and implementation work and is therefore not included in this commit.

Fixes: #275

Thanks for considering,
Kevin
