### PR TITLE
Add new properties to `no-unsupported-features/es-syntax` rule doc

### DIFF
--- a/docs/rules/no-unsupported-features/es-syntax.md
+++ b/docs/rules/no-unsupported-features/es-syntax.md
@@ -68,6 +68,8 @@ The `"ignores"` option accepts an array of the following strings.
 
 - `"bigint"`
 - `"dynamicImport"`
+- `"optionalChaining"`
+- `"nullishCoalescingOperators"`
 
 **ES2019:**
 


### PR DESCRIPTION
This PR adds the new properties to the `node/no-unsupported-features/es-syntax` rule document.