### PR TITLE
Add syntax check for ES2021 to `no-unsupported-features/es-syntax` rule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,13 +31,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        eslint: [6.x, 5.x]
-        node: [13.x, 12.x, 10.x, 8.x]
+        eslint: [7.x, 6.x, 5.x]
+        node: [14.x, 12.x, 10.x, 8.x]
         exclude:
           # On Windows, run tests with only the latest LTS environments.
           - os: windows-latest
+            eslint: 7.x
+            node: 12.x
+          - os: windows-latest
+            eslint: 7.x
+            node: 10.x
+          - os: windows-latest
+            eslint: 7.x
+            node: 8.x
+          - os: windows-latest
             eslint: 6.x
-            node: 13.x
+            node: 14.x
+          - os: windows-latest
+            eslint: 6.x
+            node: 12.x
           - os: windows-latest
             eslint: 6.x
             node: 10.x
@@ -46,7 +58,7 @@ jobs:
             node: 8.x
           - os: windows-latest
             eslint: 5.x
-            node: 13.x
+            node: 14.x
           - os: windows-latest
             eslint: 5.x
             node: 12.x
@@ -58,8 +70,20 @@ jobs:
             node: 8.x
           # On macOS, run tests with only the latest LTS environments.
           - os: macOS-latest
+            eslint: 7.x
+            node: 12.x
+          - os: macOS-latest
+            eslint: 7.x
+            node: 10.x
+          - os: macOS-latest
+            eslint: 7.x
+            node: 8.x
+          - os: macOS-latest
             eslint: 6.x
-            node: 13.x
+            node: 14.x
+          - os: macOS-latest
+            eslint: 6.x
+            node: 12.x
           - os: macOS-latest
             eslint: 6.x
             node: 10.x
@@ -68,7 +92,7 @@ jobs:
             node: 8.x
           - os: macOS-latest
             eslint: 5.x
-            node: 13.x
+            node: 14.x
           - os: macOS-latest
             eslint: 5.x
             node: 12.x
@@ -78,10 +102,14 @@ jobs:
           - os: macOS-latest
             eslint: 5.x
             node: 8.x
+          # Run ESLint 7.x tests on only the supports LTS Node.
+          - os: ubuntu-latest
+            eslint: 7.x
+            node: 8.x
           # Run ESLint 5.x tests on only the latest LTS Node.
           - os: ubuntu-latest
             eslint: 5.x
-            node: 13.x
+            node: 12.x
           - os: ubuntu-latest
             eslint: 5.x
             node: 10.x

--- a/docs/rules/no-unsupported-features/es-syntax.md
+++ b/docs/rules/no-unsupported-features/es-syntax.md
@@ -64,6 +64,11 @@ The `"ignores"` option accepts an array of the following strings.
 
 <details>
 
+**ES2021:**
+
+- `"logicalAssignmentOperators"`
+- `"numericSeparators"`
+
 **ES2020:**
 
 - `"bigint"`

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -401,6 +401,28 @@ const features = {
             },
         ],
     },
+
+    //--------------------------------------------------------------------------
+    // ES2021
+    //--------------------------------------------------------------------------
+    logicalAssignmentOperators: {
+        ruleId: "no-logical-assignment-operators",
+        cases: [
+            {
+                supported: "15.0.0",
+                messageId: "no-logical-assignment-operators",
+            },
+        ],
+    },
+    numericSeparators: {
+        ruleId: "no-numeric-separators",
+        cases: [
+            {
+                supported: "12.5.0",
+                messageId: "no-numeric-separators",
+            },
+        ],
+    },
 }
 const keywords = Object.keys(features)
 
@@ -651,6 +673,14 @@ module.exports = {
                 "Optional chainings are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
             "no-nullish-coalescing-operators":
                 "Nullish coalescing operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+
+            //------------------------------------------------------------------
+            // ES2021
+            //------------------------------------------------------------------
+            "no-logical-assignment-operators":
+                "Logical assignment operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+            "no-numeric-separators":
+                "Numeric separators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
         },
     },
     create(context) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^10.0.3",
     "codecov": "^3.3.0",
-    "eslint": "^6.3.0",
+    "eslint": "^7.27.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -9,12 +9,19 @@ const { Linter, RuleTester } = require("eslint")
 const { builtin } = require("globals")
 const rule = require("../../../../lib/rules/no-unsupported-features/es-syntax")
 
-const ES2020Supported = (() => {
-    const config = { parserOptions: { ecmaVersion: 2020 } }
+const ES2021Supported = (() => {
+    const config = { parserOptions: { ecmaVersion: 2021 } }
     const messages = new Linter().verify("0n", config)
     return messages.length === 0
 })()
-const ecmaVersion = ES2020Supported ? 2020 : 2019
+const ES2020Supported =
+    ES2021Supported ||
+    (() => {
+        const config = { parserOptions: { ecmaVersion: 2020 } }
+        const messages = new Linter().verify("0n", config)
+        return messages.length === 0
+    })()
+const ecmaVersion = ES2021Supported ? 2021 : ES2020Supported ? 2020 : 2019
 
 /**
  * Makes a file path to a fixture.
@@ -2556,6 +2563,94 @@ ruleTester.run(
                             data: {
                                 supported: "14.0.0",
                                 version: "13.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+
+        //----------------------------------------------------------------------
+        // ES2021
+        //----------------------------------------------------------------------
+        {
+            keyword: "logicalAssignmentOperators",
+            requiredEcmaVersion: 2021,
+            valid: [
+                {
+                    code: "a ||= b",
+                    options: [{ version: "15.0.0" }],
+                },
+                {
+                    code: "a &&= b",
+                    options: [{ version: "15.0.0" }],
+                },
+                {
+                    code: "a ??= b",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "a ||= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "a &&= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "a ??= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "numericSeparators",
+            requiredEcmaVersion: 2021,
+            valid: [
+                {
+                    code: "a = 123_456_789",
+                    options: [{ version: "12.5.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "a = 123_456_789",
+                    options: [{ version: "12.4.0" }],
+                    errors: [
+                        {
+                            messageId: "no-numeric-separators",
+                            data: {
+                                supported: "12.5.0",
+                                version: "12.4.0",
                             },
                         },
                     ],


### PR DESCRIPTION
This PR adds a syntax check for ES2021 to the `node/no-unsupported-features/es-syntax` rule.