### PR TITLE
Add builtins check for ES2021 to `no-unsupported-features/es-builtins` rule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,13 +31,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        eslint: [6.x, 5.x]
-        node: [13.x, 12.x, 10.x, 8.x]
+        eslint: [7.x, 6.x, 5.x]
+        node: [14.x, 12.x, 10.x, 8.x]
         exclude:
           # On Windows, run tests with only the latest LTS environments.
           - os: windows-latest
+            eslint: 7.x
+            node: 12.x
+          - os: windows-latest
+            eslint: 7.x
+            node: 10.x
+          - os: windows-latest
+            eslint: 7.x
+            node: 8.x
+          - os: windows-latest
             eslint: 6.x
-            node: 13.x
+            node: 14.x
+          - os: windows-latest
+            eslint: 6.x
+            node: 12.x
           - os: windows-latest
             eslint: 6.x
             node: 10.x
@@ -46,7 +58,7 @@ jobs:
             node: 8.x
           - os: windows-latest
             eslint: 5.x
-            node: 13.x
+            node: 14.x
           - os: windows-latest
             eslint: 5.x
             node: 12.x
@@ -58,8 +70,20 @@ jobs:
             node: 8.x
           # On macOS, run tests with only the latest LTS environments.
           - os: macOS-latest
+            eslint: 7.x
+            node: 12.x
+          - os: macOS-latest
+            eslint: 7.x
+            node: 10.x
+          - os: macOS-latest
+            eslint: 7.x
+            node: 8.x
+          - os: macOS-latest
             eslint: 6.x
-            node: 13.x
+            node: 14.x
+          - os: macOS-latest
+            eslint: 6.x
+            node: 12.x
           - os: macOS-latest
             eslint: 6.x
             node: 10.x
@@ -68,7 +92,7 @@ jobs:
             node: 8.x
           - os: macOS-latest
             eslint: 5.x
-            node: 13.x
+            node: 14.x
           - os: macOS-latest
             eslint: 5.x
             node: 12.x
@@ -78,10 +102,14 @@ jobs:
           - os: macOS-latest
             eslint: 5.x
             node: 8.x
+          # Run ESLint 7.x tests on only the supports LTS Node.
+          - os: ubuntu-latest
+            eslint: 7.x
+            node: 8.x
           # Run ESLint 5.x tests on only the latest LTS Node.
           - os: ubuntu-latest
             eslint: 5.x
-            node: 13.x
+            node: 12.x
           - os: ubuntu-latest
             eslint: 5.x
             node: 10.x

--- a/docs/rules/no-unsupported-features/es-builtins.md
+++ b/docs/rules/no-unsupported-features/es-builtins.md
@@ -61,6 +61,13 @@ The `"ignores"` option accepts an array of the following strings.
 
 <details>
 
+**ES2021:**
+
+- `"AggregateError"`
+- `"Promise.any"`
+- `"WeakRef"`
+- `"FinalizationRegistry"`
+
 **ES2020:**
 
 - `"BigInt"`

--- a/lib/rules/no-unsupported-features/es-builtins.js
+++ b/lib/rules/no-unsupported-features/es-builtins.js
@@ -10,12 +10,18 @@ const enumeratePropertyNames = require("../../util/enumerate-property-names")
 
 const trackMap = {
     globals: {
+        AggregateError: {
+            [READ]: { supported: "15.0.0" },
+        },
         Array: {
             from: { [READ]: { supported: "4.0.0" } },
             of: { [READ]: { supported: "4.0.0" } },
         },
         BigInt: {
             [READ]: { supported: "10.4.0" },
+        },
+        FinalizationRegistry: {
+            [READ]: { supported: "14.6.0" },
         },
         Map: {
             [READ]: { supported: "0.12.0" },
@@ -63,6 +69,7 @@ const trackMap = {
         Promise: {
             [READ]: { supported: "0.12.0" },
             allSettled: { [READ]: { supported: "12.9.0" } },
+            any: { [READ]: { supported: "15.0.0" } },
         },
         Proxy: {
             [READ]: { supported: "6.0.0" },
@@ -118,6 +125,9 @@ const trackMap = {
         },
         WeakMap: {
             [READ]: { supported: "0.12.0" },
+        },
+        WeakRef: {
+            [READ]: { supported: "14.6.0" },
         },
         WeakSet: {
             [READ]: { supported: "0.12.0" },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^10.0.3",
     "codecov": "^3.3.0",
-    "eslint": "^6.3.0",
+    "eslint": "^7.27.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
-    "globals": "^11.12.0",
+    "globals": "^13.9.0",
     "mocha": "^6.1.4",
     "nyc": "^14.0.0",
     "opener": "^1.5.1",

--- a/tests/lib/rules/no-unsupported-features/es-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/es-builtins.js
@@ -63,6 +63,31 @@ ruleTester.run(
     rule,
     concat([
         {
+            keyword: "AggregateError",
+            valid: [
+                {
+                    code: "if (error instanceof AggregateError) {}",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "if (error instanceof AggregateError) {}",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "AggregateError",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             keyword: "Array.from",
             valid: [
                 {
@@ -169,6 +194,31 @@ ruleTester.run(
                                 name: "BigInt",
                                 supported: "10.4.0",
                                 version: "10.3.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "FinalizationRegistry",
+            valid: [
+                {
+                    code: "new FinalizationRegistry(() => {})",
+                    options: [{ version: "14.6.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "new FinalizationRegistry(() => {})",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "FinalizationRegistry",
+                                supported: "14.6.0",
+                                version: "14.5.0",
                             },
                         },
                     ],
@@ -1201,6 +1251,49 @@ ruleTester.run(
             ],
         },
         {
+            keyword: "Promise.any",
+            valid: [
+                {
+                    code: "(function(Promise) { Promise.any }(a))",
+                    options: [{ version: "14.0.0" }],
+                },
+                {
+                    code: "Promise.any",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "Promise.any",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "Promise.any",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "function wrap() { Promise.any }",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "Promise.any",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             keyword: "Proxy",
             valid: [
                 {
@@ -1992,6 +2085,49 @@ ruleTester.run(
                                 name: "WeakMap",
                                 supported: "0.12.0",
                                 version: "0.11.9",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "WeakRef",
+            valid: [
+                {
+                    code: "(function(WeakRef) { WeakRef }(a))",
+                    options: [{ version: "14.5.0" }],
+                },
+                {
+                    code: "WeakRef",
+                    options: [{ version: "14.6.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "WeakRef",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "WeakRef",
+                                supported: "14.6.0",
+                                version: "14.5.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "function wrap() { WeakRef }",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "WeakRef",
+                                supported: "14.6.0",
+                                version: "14.5.0",
                             },
                         },
                     ],


### PR DESCRIPTION

This PR adds a builtins check for ES2021 to the `node/no-unsupported-features/es-builtins` rule.