### PR TITLE
Fix ES6 modules support

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -125,7 +125,7 @@ const features = {
         ruleId: "no-modules",
         cases: [
             {
-                supported: null,
+                supported: "13.2.0",
                 messageId: "no-modules",
             },
         ],


### PR DESCRIPTION
Node has stable support for ES6 modules since 13.2.0.