### PR TITLE
feat: Support ESLint 8.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,13 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node: 14
+          node-version: 14
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -27,120 +25,41 @@ jobs:
 
   test:
     name: Test
-
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        eslint: [7, 6, 5]
-        node: [14, 12, 12.0, 10, 10.12]
-        exclude:
-          # On Windows, run tests with only the latest LTS environments.
-          - os: windows-latest
-            eslint: 7
+        os: [ubuntu-latest]
+        eslint: [7]
+        node: [14]
+        include:
+          # On other platforms
+#          - eslint: 7
+#            node: 14
+#            os: windows-latest
+          - eslint: 7
             node: 14
-          - os: windows-latest
-            eslint: 7
-            node: 12.0
-          - os: windows-latest
-            eslint: 7
+            os: macos-latest
+          # On old Node.js versions
+          - eslint: 7
+            node: 12
+            os: ubuntu-latest
+          - eslint: 7
             node: 10
-          - os: windows-latest
-            eslint: 7
-            node: 10.12
-          - os: windows-latest
-            eslint: 6
+            os: ubuntu-latest
+          # On old ESLint versions
+          - eslint: 6
             node: 14
-          - os: windows-latest
-            eslint: 6
-            node: 12.0
-          - os: windows-latest
-            eslint: 6
-            node: 10
-          - os: windows-latest
-            eslint: 6
-            node: 10.12
-          - os: windows-latest
-            eslint: 5
+            os: ubuntu-latest
+          - eslint: 5
             node: 14
-          - os: windows-latest
-            eslint: 5
-            node: 12.0
-          - os: windows-latest
-            eslint: 5
-            node: 10
-          - os: windows-latest
-            eslint: 5
-            node: 10.12
-          # On macOS, run tests with only the latest LTS environments.
-          - os: macOS-latest
-            eslint: 7
-            node: 14
-          - os: macOS-latest
-            eslint: 7
-            node: 12.0
-          - os: macOS-latest
-            eslint: 7
-            node: 10
-          - os: macOS-latest
-            eslint: 7
-            node: 10.12
-          - os: macOS-latest
-            eslint: 6
-            node: 14
-          - os: macOS-latest
-            eslint: 6
-            node: 12.0
-          - os: macOS-latest
-            eslint: 6
-            node: 10
-          - os: macOS-latest
-            eslint: 6
-            node: 10.12
-          - os: macOS-latest
-            eslint: 5
-            node: 14
-          - os: macOS-latest
-            eslint: 5
-            node: 12.0
-          - os: macOS-latest
-            eslint: 5
-            node: 10
-          - os: macOS-latest
-            eslint: 5
-            node: 10.12
-          # Run ESLint 6 tests on only the latest LTS Node.
-          - os: ubuntu-latest
-            eslint: 6
-            node: 14
-          - os: ubuntu-latest
-            eslint: 6
-            node: 12.0
-          - os: ubuntu-latest
-            eslint: 6
-            node: 10
-          - os: ubuntu-latest
-            eslint: 6
-            node: 10.12
-          # Run ESLint 5 tests on only the latest LTS Node.
-          - os: ubuntu-latest
-            eslint: 5
-            node: 14
-          - os: ubuntu-latest
-            eslint: 6
-            node: 12.0
-          - os: ubuntu-latest
-            eslint: 5
-            node: 10
-          - os: ubuntu-latest
-            eslint: 5
-            node: 10.12
-
+            os: ubuntu-latest
+          # On the minimum supported ESLint/Node.js version
+          - eslint: 5
+            node: 8.10.0
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Install Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Install Packages
@@ -54,14 +54,14 @@ jobs:
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
           - eslint: 5.16.0
-            node: 8.10.0
+            node: 10.0.0
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - name: Install Packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -29,16 +29,19 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         eslint: [7]
-        node: [14]
+        node: [16]
         include:
           # On other platforms
           - eslint: 7
-            node: 14
+            node: 16
             os: windows-latest
           - eslint: 7
-            node: 14
+            node: 16
             os: macos-latest
           # On old Node.js versions
+          - eslint: 7
+            node: 14
+            os: ubuntu-latest
           - eslint: 7
             node: 12
             os: ubuntu-latest
@@ -47,15 +50,16 @@ jobs:
             os: ubuntu-latest
           # On old ESLint versions
           - eslint: 6
-            node: 14
+            node: 16
             os: ubuntu-latest
           - eslint: 5
-            node: 14
+            node: 16
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
           - eslint: 5.16.0
             node: 10.0.0
             os: ubuntu-latest
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,27 +28,27 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        eslint: [7]
+        eslint: ["^8.0.0-0"]
         node: [16]
         include:
           # On other platforms
-          - eslint: 7
+          - eslint: "^8.0.0-0"
             node: 16
             os: windows-latest
-          - eslint: 7
+          - eslint: "^8.0.0-0"
             node: 16
             os: macos-latest
           # On old Node.js versions
-          - eslint: 7
+          - eslint: "^8.0.0-0"
             node: 14
             os: ubuntu-latest
-          - eslint: 7
+          - eslint: "^8.0.0-0"
             node: 12
             os: ubuntu-latest
-          - eslint: 7
-            node: 10
-            os: ubuntu-latest
           # On old ESLint versions
+          - eslint: 7
+            node: 16
+            os: ubuntu-latest
           - eslint: 6
             node: 16
             os: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
           - eslint: 5.16.0
-            node: 10.0.0
+            node: 12.22.0
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node: 12.x
+          node: 14
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -31,63 +31,109 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        eslint: [6.x, 5.x]
-        node: [13.x, 12.x, 10.x, 8.x]
+        eslint: [7, 6, 5]
+        node: [14, 12, 12.0, 10, 10.12]
         exclude:
           # On Windows, run tests with only the latest LTS environments.
           - os: windows-latest
-            eslint: 6.x
-            node: 13.x
+            eslint: 7
+            node: 14
           - os: windows-latest
-            eslint: 6.x
-            node: 10.x
+            eslint: 7
+            node: 12.0
           - os: windows-latest
-            eslint: 6.x
-            node: 8.x
+            eslint: 7
+            node: 10
           - os: windows-latest
-            eslint: 5.x
-            node: 13.x
+            eslint: 7
+            node: 10.12
           - os: windows-latest
-            eslint: 5.x
-            node: 12.x
+            eslint: 6
+            node: 14
           - os: windows-latest
-            eslint: 5.x
-            node: 10.x
+            eslint: 6
+            node: 12.0
           - os: windows-latest
-            eslint: 5.x
-            node: 8.x
+            eslint: 6
+            node: 10
+          - os: windows-latest
+            eslint: 6
+            node: 10.12
+          - os: windows-latest
+            eslint: 5
+            node: 14
+          - os: windows-latest
+            eslint: 5
+            node: 12.0
+          - os: windows-latest
+            eslint: 5
+            node: 10
+          - os: windows-latest
+            eslint: 5
+            node: 10.12
           # On macOS, run tests with only the latest LTS environments.
           - os: macOS-latest
-            eslint: 6.x
-            node: 13.x
+            eslint: 7
+            node: 14
           - os: macOS-latest
-            eslint: 6.x
-            node: 10.x
+            eslint: 7
+            node: 12.0
           - os: macOS-latest
-            eslint: 6.x
-            node: 8.x
+            eslint: 7
+            node: 10
           - os: macOS-latest
-            eslint: 5.x
-            node: 13.x
+            eslint: 7
+            node: 10.12
           - os: macOS-latest
-            eslint: 5.x
-            node: 12.x
+            eslint: 6
+            node: 14
           - os: macOS-latest
-            eslint: 5.x
-            node: 10.x
+            eslint: 6
+            node: 12.0
           - os: macOS-latest
-            eslint: 5.x
-            node: 8.x
-          # Run ESLint 5.x tests on only the latest LTS Node.
+            eslint: 6
+            node: 10
+          - os: macOS-latest
+            eslint: 6
+            node: 10.12
+          - os: macOS-latest
+            eslint: 5
+            node: 14
+          - os: macOS-latest
+            eslint: 5
+            node: 12.0
+          - os: macOS-latest
+            eslint: 5
+            node: 10
+          - os: macOS-latest
+            eslint: 5
+            node: 10.12
+          # Run ESLint 6 tests on only the latest LTS Node.
           - os: ubuntu-latest
-            eslint: 5.x
-            node: 13.x
+            eslint: 6
+            node: 14
           - os: ubuntu-latest
-            eslint: 5.x
-            node: 10.x
+            eslint: 6
+            node: 12.0
           - os: ubuntu-latest
-            eslint: 5.x
-            node: 8.x
+            eslint: 6
+            node: 10
+          - os: ubuntu-latest
+            eslint: 6
+            node: 10.12
+          # Run ESLint 5 tests on only the latest LTS Node.
+          - os: ubuntu-latest
+            eslint: 5
+            node: 14
+          - os: ubuntu-latest
+            eslint: 6
+            node: 12.0
+          - os: ubuntu-latest
+            eslint: 5
+            node: 10
+          - os: ubuntu-latest
+            eslint: 5
+            node: 10.12
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,9 +32,9 @@ jobs:
         node: [14]
         include:
           # On other platforms
-#          - eslint: 7
-#            node: 14
-#            os: windows-latest
+          - eslint: 7
+            node: 14
+            os: windows-latest
           - eslint: 7
             node: 14
             os: macos-latest
@@ -53,7 +53,7 @@ jobs:
             node: 14
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
-          - eslint: 5
+          - eslint: 5.16.0
             node: 8.10.0
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additional ESLint's rules for Node.js
 $ npm install --save-dev eslint eslint-plugin-node
 ```
 
-- Requires Node.js `>=8.10.0`
+- Requires Node.js `^10.0.0 || ^12.0.0 || >= 14.0.0`
 - Requires ESLint `>=5.16.0`
 
 **Note:** It recommends a use of [the "engines" field of package.json](https://docs.npmjs.com/files/package.json#engines). The "engines" field is used by `node/no-unsupported-features/*` rules.
@@ -23,25 +23,22 @@ $ npm install --save-dev eslint eslint-plugin-node
 
 ```jsonc
 {
-    "extends": [
-        "eslint:recommended",
-        "plugin:node/recommended"
-    ],
-    "parserOptions": {
-        // Only ESLint 6.2.0 and later support ES2020.
-        "ecmaVersion": 2020
-    },
-    "rules": {
-        "node/exports-style": ["error", "module.exports"],
-        "node/file-extension-in-import": ["error", "always"],
-        "node/prefer-global/buffer": ["error", "always"],
-        "node/prefer-global/console": ["error", "always"],
-        "node/prefer-global/process": ["error", "always"],
-        "node/prefer-global/url-search-params": ["error", "always"],
-        "node/prefer-global/url": ["error", "always"],
-        "node/prefer-promises/dns": "error",
-        "node/prefer-promises/fs": "error"
-    }
+  "extends": ["eslint:recommended", "plugin:node/recommended"],
+  "parserOptions": {
+    // Only ESLint 6.2.0 and later support ES2020.
+    "ecmaVersion": 2020
+  },
+  "rules": {
+    "node/exports-style": ["error", "module.exports"],
+    "node/file-extension-in-import": ["error", "always"],
+    "node/prefer-global/buffer": ["error", "always"],
+    "node/prefer-global/console": ["error", "always"],
+    "node/prefer-global/process": ["error", "always"],
+    "node/prefer-global/url-search-params": ["error", "always"],
+    "node/prefer-global/url": ["error", "always"],
+    "node/prefer-promises/dns": "error",
+    "node/prefer-promises/fs": "error"
+  }
 }
 ```
 
@@ -49,12 +46,12 @@ $ npm install --save-dev eslint eslint-plugin-node
 
 ```json
 {
-    "name": "your-module",
-    "version": "1.0.0",
-    "type": "commonjs",
-    "engines": {
-        "node": ">=8.10.0"
-    }
+  "name": "your-module",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=10.0.0"
+  }
 }
 ```
 
@@ -64,65 +61,66 @@ $ npm install --save-dev eslint eslint-plugin-node
 - ✒️ - the mark of fixable rules.
 
 <!--RULES_TABLE_START-->
+
 ### Possible Errors
 
-| Rule ID | Description |    |
-|:--------|:------------|:--:|
-| [node/handle-callback-err](./docs/rules/handle-callback-err.md) | require error handling in callbacks |  |
-| [node/no-callback-literal](./docs/rules/no-callback-literal.md) | ensure Node.js-style error-first callback pattern is followed |  |
-| [node/no-exports-assign](./docs/rules/no-exports-assign.md) | disallow the assignment to `exports` | ⭐️ |
-| [node/no-extraneous-import](./docs/rules/no-extraneous-import.md) | disallow `import` declarations which import extraneous modules | ⭐️ |
-| [node/no-extraneous-require](./docs/rules/no-extraneous-require.md) | disallow `require()` expressions which import extraneous modules | ⭐️ |
-| [node/no-missing-import](./docs/rules/no-missing-import.md) | disallow `import` declarations which import non-existence modules | ⭐️ |
-| [node/no-missing-require](./docs/rules/no-missing-require.md) | disallow `require()` expressions which import non-existence modules | ⭐️ |
-| [node/no-new-require](./docs/rules/no-new-require.md) | disallow `new` operators with calls to `require` |  |
-| [node/no-path-concat](./docs/rules/no-path-concat.md) | disallow string concatenation with `__dirname` and `__filename` |  |
-| [node/no-process-exit](./docs/rules/no-process-exit.md) | disallow the use of `process.exit()` |  |
-| [node/no-unpublished-bin](./docs/rules/no-unpublished-bin.md) | disallow `bin` files that npm ignores | ⭐️ |
-| [node/no-unpublished-import](./docs/rules/no-unpublished-import.md) | disallow `import` declarations which import private modules | ⭐️ |
-| [node/no-unpublished-require](./docs/rules/no-unpublished-require.md) | disallow `require()` expressions which import private modules | ⭐️ |
-| [node/no-unsupported-features/es-builtins](./docs/rules/no-unsupported-features/es-builtins.md) | disallow unsupported ECMAScript built-ins on the specified version | ⭐️ |
-| [node/no-unsupported-features/es-syntax](./docs/rules/no-unsupported-features/es-syntax.md) | disallow unsupported ECMAScript syntax on the specified version | ⭐️ |
-| [node/no-unsupported-features/node-builtins](./docs/rules/no-unsupported-features/node-builtins.md) | disallow unsupported Node.js built-in APIs on the specified version | ⭐️ |
-| [node/process-exit-as-throw](./docs/rules/process-exit-as-throw.md) | make `process.exit()` expressions the same code path as `throw` | ⭐️ |
-| [node/shebang](./docs/rules/shebang.md) | suggest correct usage of shebang | ⭐️✒️ |
+| Rule ID                                                                                             | Description                                                         |       |
+| :-------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------ | :---: |
+| [node/handle-callback-err](./docs/rules/handle-callback-err.md)                                     | require error handling in callbacks                                 |       |
+| [node/no-callback-literal](./docs/rules/no-callback-literal.md)                                     | ensure Node.js-style error-first callback pattern is followed       |       |
+| [node/no-exports-assign](./docs/rules/no-exports-assign.md)                                         | disallow the assignment to `exports`                                |  ⭐️  |
+| [node/no-extraneous-import](./docs/rules/no-extraneous-import.md)                                   | disallow `import` declarations which import extraneous modules      |  ⭐️  |
+| [node/no-extraneous-require](./docs/rules/no-extraneous-require.md)                                 | disallow `require()` expressions which import extraneous modules    |  ⭐️  |
+| [node/no-missing-import](./docs/rules/no-missing-import.md)                                         | disallow `import` declarations which import non-existence modules   |  ⭐️  |
+| [node/no-missing-require](./docs/rules/no-missing-require.md)                                       | disallow `require()` expressions which import non-existence modules |  ⭐️  |
+| [node/no-new-require](./docs/rules/no-new-require.md)                                               | disallow `new` operators with calls to `require`                    |       |
+| [node/no-path-concat](./docs/rules/no-path-concat.md)                                               | disallow string concatenation with `__dirname` and `__filename`     |       |
+| [node/no-process-exit](./docs/rules/no-process-exit.md)                                             | disallow the use of `process.exit()`                                |       |
+| [node/no-unpublished-bin](./docs/rules/no-unpublished-bin.md)                                       | disallow `bin` files that npm ignores                               |  ⭐️  |
+| [node/no-unpublished-import](./docs/rules/no-unpublished-import.md)                                 | disallow `import` declarations which import private modules         |  ⭐️  |
+| [node/no-unpublished-require](./docs/rules/no-unpublished-require.md)                               | disallow `require()` expressions which import private modules       |  ⭐️  |
+| [node/no-unsupported-features/es-builtins](./docs/rules/no-unsupported-features/es-builtins.md)     | disallow unsupported ECMAScript built-ins on the specified version  |  ⭐️  |
+| [node/no-unsupported-features/es-syntax](./docs/rules/no-unsupported-features/es-syntax.md)         | disallow unsupported ECMAScript syntax on the specified version     |  ⭐️  |
+| [node/no-unsupported-features/node-builtins](./docs/rules/no-unsupported-features/node-builtins.md) | disallow unsupported Node.js built-in APIs on the specified version |  ⭐️  |
+| [node/process-exit-as-throw](./docs/rules/process-exit-as-throw.md)                                 | make `process.exit()` expressions the same code path as `throw`     |  ⭐️  |
+| [node/shebang](./docs/rules/shebang.md)                                                             | suggest correct usage of shebang                                    | ⭐️✒️ |
 
 ### Best Practices
 
-| Rule ID | Description |    |
-|:--------|:------------|:--:|
+| Rule ID                                                     | Description              |     |
+| :---------------------------------------------------------- | :----------------------- | :-: |
 | [node/no-deprecated-api](./docs/rules/no-deprecated-api.md) | disallow deprecated APIs | ⭐️ |
 
 ### Stylistic Issues
 
-| Rule ID | Description |    |
-|:--------|:------------|:--:|
-| [node/callback-return](./docs/rules/callback-return.md) | require `return` statements after callbacks |  |
-| [node/exports-style](./docs/rules/exports-style.md) | enforce either `module.exports` or `exports` |  |
-| [node/file-extension-in-import](./docs/rules/file-extension-in-import.md) | enforce the style of file extensions in `import` declarations | ✒️ |
-| [node/global-require](./docs/rules/global-require.md) | require `require()` calls to be placed at top-level module scope |  |
-| [node/no-mixed-requires](./docs/rules/no-mixed-requires.md) | disallow `require` calls to be mixed with regular variable declarations |  |
-| [node/no-process-env](./docs/rules/no-process-env.md) | disallow the use of `process.env` |  |
-| [node/no-restricted-import](./docs/rules/no-restricted-import.md) | disallow specified modules when loaded by `import` declarations |  |
-| [node/no-restricted-require](./docs/rules/no-restricted-require.md) | disallow specified modules when loaded by `require` |  |
-| [node/no-sync](./docs/rules/no-sync.md) | disallow synchronous methods |  |
-| [node/prefer-global/buffer](./docs/rules/prefer-global/buffer.md) | enforce either `Buffer` or `require("buffer").Buffer` |  |
-| [node/prefer-global/console](./docs/rules/prefer-global/console.md) | enforce either `console` or `require("console")` |  |
-| [node/prefer-global/process](./docs/rules/prefer-global/process.md) | enforce either `process` or `require("process")` |  |
-| [node/prefer-global/text-decoder](./docs/rules/prefer-global/text-decoder.md) | enforce either `TextDecoder` or `require("util").TextDecoder` |  |
-| [node/prefer-global/text-encoder](./docs/rules/prefer-global/text-encoder.md) | enforce either `TextEncoder` or `require("util").TextEncoder` |  |
-| [node/prefer-global/url-search-params](./docs/rules/prefer-global/url-search-params.md) | enforce either `URLSearchParams` or `require("url").URLSearchParams` |  |
-| [node/prefer-global/url](./docs/rules/prefer-global/url.md) | enforce either `URL` or `require("url").URL` |  |
-| [node/prefer-promises/dns](./docs/rules/prefer-promises/dns.md) | enforce `require("dns").promises` |  |
-| [node/prefer-promises/fs](./docs/rules/prefer-promises/fs.md) | enforce `require("fs").promises` |  |
+| Rule ID                                                                                 | Description                                                             |     |
+| :-------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :-: |
+| [node/callback-return](./docs/rules/callback-return.md)                                 | require `return` statements after callbacks                             |     |
+| [node/exports-style](./docs/rules/exports-style.md)                                     | enforce either `module.exports` or `exports`                            |     |
+| [node/file-extension-in-import](./docs/rules/file-extension-in-import.md)               | enforce the style of file extensions in `import` declarations           | ✒️  |
+| [node/global-require](./docs/rules/global-require.md)                                   | require `require()` calls to be placed at top-level module scope        |     |
+| [node/no-mixed-requires](./docs/rules/no-mixed-requires.md)                             | disallow `require` calls to be mixed with regular variable declarations |     |
+| [node/no-process-env](./docs/rules/no-process-env.md)                                   | disallow the use of `process.env`                                       |     |
+| [node/no-restricted-import](./docs/rules/no-restricted-import.md)                       | disallow specified modules when loaded by `import` declarations         |     |
+| [node/no-restricted-require](./docs/rules/no-restricted-require.md)                     | disallow specified modules when loaded by `require`                     |     |
+| [node/no-sync](./docs/rules/no-sync.md)                                                 | disallow synchronous methods                                            |     |
+| [node/prefer-global/buffer](./docs/rules/prefer-global/buffer.md)                       | enforce either `Buffer` or `require("buffer").Buffer`                   |     |
+| [node/prefer-global/console](./docs/rules/prefer-global/console.md)                     | enforce either `console` or `require("console")`                        |     |
+| [node/prefer-global/process](./docs/rules/prefer-global/process.md)                     | enforce either `process` or `require("process")`                        |     |
+| [node/prefer-global/text-decoder](./docs/rules/prefer-global/text-decoder.md)           | enforce either `TextDecoder` or `require("util").TextDecoder`           |     |
+| [node/prefer-global/text-encoder](./docs/rules/prefer-global/text-encoder.md)           | enforce either `TextEncoder` or `require("util").TextEncoder`           |     |
+| [node/prefer-global/url-search-params](./docs/rules/prefer-global/url-search-params.md) | enforce either `URLSearchParams` or `require("url").URLSearchParams`    |     |
+| [node/prefer-global/url](./docs/rules/prefer-global/url.md)                             | enforce either `URL` or `require("url").URL`                            |     |
+| [node/prefer-promises/dns](./docs/rules/prefer-promises/dns.md)                         | enforce `require("dns").promises`                                       |     |
+| [node/prefer-promises/fs](./docs/rules/prefer-promises/fs.md)                           | enforce `require("fs").promises`                                        |     |
 
 ### Deprecated rules
 
 These rules have been deprecated in accordance with the [deprecation policy](https://eslint.org/docs/user-guide/rule-deprecation), and replaced by newer rules:
 
-| Rule ID | Replaced by |
-|:--------|:------------|
-| [node/no-hide-core-modules](./docs/rules/no-hide-core-modules.md) | (nothing) |
+| Rule ID                                                                 | Replaced by                                                                                                                                                                                     |
+| :---------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [node/no-hide-core-modules](./docs/rules/no-hide-core-modules.md)       | (nothing)                                                                                                                                                                                       |
 | [node/no-unsupported-features](./docs/rules/no-unsupported-features.md) | [node/no-unsupported-features/es-syntax](./docs/rules/no-unsupported-features/es-syntax.md) and [node/no-unsupported-features/es-builtins](./docs/rules/no-unsupported-features/es-builtins.md) |
 
 <!--RULES_TABLE_END-->
@@ -153,22 +151,22 @@ Those preset config:
 `eslint-plugin-node` follows [semantic versioning](http://semver.org/) and [ESLint's Semantic Versioning Policy](https://github.com/eslint/eslint#semantic-versioning-policy).
 
 - Patch release (intended to not break your lint build)
-    - A bug fix in a rule that results in it reporting fewer errors.
-    - Improvements to documentation.
-    - Non-user-facing changes such as refactoring code, adding, deleting, or modifying tests, and increasing test coverage.
-    - Re-releasing after a failed release (i.e., publishing a release that doesn't work for anyone).
+  - A bug fix in a rule that results in it reporting fewer errors.
+  - Improvements to documentation.
+  - Non-user-facing changes such as refactoring code, adding, deleting, or modifying tests, and increasing test coverage.
+  - Re-releasing after a failed release (i.e., publishing a release that doesn't work for anyone).
 - Minor release (might break your lint build)
-    - A bug fix in a rule that results in it reporting more errors.
-    - A new rule is created.
-    - A new option to an existing rule is created.
-    - An existing rule is deprecated.
+  - A bug fix in a rule that results in it reporting more errors.
+  - A new rule is created.
+  - A new option to an existing rule is created.
+  - An existing rule is deprecated.
 - Major release (likely to break your lint build)
-    - A support for old Node version is dropped.
-    - A support for old ESLint version is dropped.
-    - An existing rule is changed in it reporting more errors.
-    - An existing rule is removed.
-    - An existing option of a rule is removed.
-    - An existing config is updated.
+  - A support for old Node version is dropped.
+  - A support for old ESLint version is dropped.
+  - An existing rule is changed in it reporting more errors.
+  - An existing rule is removed.
+  - An existing option of a rule is removed.
+  - An existing config is updated.
 
 ## 📰 Changelog
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additional ESLint's rules for Node.js
 $ npm install --save-dev eslint eslint-plugin-node
 ```
 
-- Requires Node.js `^10.0.0 || ^12.0.0 || >= 14.0.0`
+- Requires Node.js `"^12.22.0 || ^14.17.0 || >=16.0.0"`
 - Requires ESLint `>=5.16.0`
 
 **Note:** It recommends a use of [the "engines" field of package.json](https://docs.npmjs.com/files/package.json#engines). The "engines" field is used by `node/no-unsupported-features/*` rules.
@@ -50,7 +50,7 @@ $ npm install --save-dev eslint eslint-plugin-node
   "version": "1.0.0",
   "type": "commonjs",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.22.0"
   }
 }
 ```

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -6,7 +6,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "require `return` statements after callbacks",
             category: "Stylistic Issues",
@@ -14,16 +13,17 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/callback-return.md",
         },
+        fixable: null,
+        messages: {
+            missingReturn: "Expected return with your callback function.",
+        },
         schema: [
             {
                 type: "array",
                 items: { type: "string" },
             },
         ],
-        fixable: null,
-        messages: {
-            missingReturn: "Expected return with your callback function.",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -148,7 +148,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/exports-style.md",
         },
-        type: "suggestion",
         fixable: null,
         schema: [
             {
@@ -161,6 +160,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -49,7 +49,6 @@ function isShadowed(scope, node) {
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description:
                 "require `require()` calls to be placed at top-level module scope",
@@ -59,10 +58,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/global-require.md",
         },
         fixable: null,
-        schema: [],
         messages: {
             unexpected: "Unexpected require().",
         },
+        schema: [],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -6,7 +6,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "require error handling in callbacks",
             category: "Possible Errors",
@@ -15,14 +14,15 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/handle-callback-err.md",
         },
         fixable: null,
+        messages: {
+            expected: "Expected error to be handled.",
+        },
         schema: [
             {
                 type: "string",
             },
         ],
-        messages: {
-            expected: "Expected error to be handled.",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-callback-literal.js
+++ b/lib/rules/no-callback-literal.js
@@ -14,9 +14,9 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-callback-literal.md",
         },
-        type: "problem",
         fixable: null,
         schema: [],
+        type: "problem",
     },
 
     create(context) {

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -659,8 +659,8 @@ function toName(type, path) {
     return type === ReferenceTracker.CALL
         ? `${baseName}()`
         : type === ReferenceTracker.CONSTRUCT
-            ? `new ${baseName}()`
-            : baseName
+        ? `new ${baseName}()`
+        : baseName
 }
 
 /**
@@ -688,7 +688,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-deprecated-api.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -720,6 +719,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const {

--- a/lib/rules/no-extraneous-import.js
+++ b/lib/rules/no-extraneous-import.js
@@ -21,7 +21,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-extraneous-import.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -35,6 +34,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-extraneous-require.js
+++ b/lib/rules/no-extraneous-require.js
@@ -21,7 +21,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-extraneous-require.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -35,6 +34,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-hide-core-modules.js
+++ b/lib/rules/no-hide-core-modules.js
@@ -50,6 +50,7 @@ const BACK_SLASH = /\\/gu
 
 module.exports = {
     meta: {
+        deprecated: true,
         docs: {
             description:
                 "disallow third-party modules which are hiding core modules",
@@ -58,8 +59,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-hide-core-modules.md",
         },
-        type: "problem",
-        deprecated: true,
         fixable: null,
         schema: [
             {
@@ -77,6 +76,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         if (context.getFilename() === "<input>") {

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -20,7 +20,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-missing-import.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -33,6 +32,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -20,7 +20,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-missing-require.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -33,6 +32,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -67,7 +67,6 @@ const BUILTIN_MODULES = [
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description:
                 "disallow `require` calls to be mixed with regular variable declarations",
@@ -77,6 +76,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-mixed-requires.md",
         },
         fixable: null,
+        messages: {
+            noMixRequire: "Do not mix 'require' and other declarations.",
+            noMixCoreModuleFileComputed:
+                "Do not mix core, module, file and computed requires.",
+        },
         schema: [
             {
                 oneOf: [
@@ -98,11 +102,7 @@ module.exports = {
                 ],
             },
         ],
-        messages: {
-            noMixRequire: "Do not mix 'require' and other declarations.",
-            noMixCoreModuleFileComputed:
-                "Do not mix core, module, file and computed requires.",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -6,7 +6,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "disallow `new` operators with calls to `require`",
             category: "Possible Errors",
@@ -15,10 +14,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-new-require.md",
         },
         fixable: null,
-        schema: [],
         messages: {
             noNewRequire: "Unexpected use of new with require.",
         },
+        schema: [],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -158,7 +158,6 @@ function isConcat(node, sepNodes, globalScope) {
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description:
                 "disallow string concatenation with `__dirname` and `__filename`",
@@ -168,11 +167,12 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-path-concat.md",
         },
         fixable: null,
-        schema: [],
         messages: {
             usePathFunctions:
                 "Use path.join() or path.resolve() instead of string concatenation.",
         },
+        schema: [],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -10,7 +10,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "disallow the use of `process.env`",
             category: "Stylistic Issues",
@@ -19,10 +18,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-process-env.md",
         },
         fixable: null,
-        schema: [],
         messages: {
             unexpectedProcessEnv: "Unexpected use of process.env.",
         },
+        schema: [],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -6,7 +6,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "disallow the use of `process.exit()`",
             category: "Possible Errors",
@@ -15,10 +14,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-process-exit.md",
         },
         fixable: null,
-        schema: [],
         messages: {
             noProcessExit: "Don't use process.exit(); throw an error instead.",
         },
+        schema: [],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-restricted-import.js
+++ b/lib/rules/no-restricted-import.js
@@ -9,7 +9,6 @@ const visit = require("../util/visit-import")
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description:
                 "disallow specified modules when loaded by `import` declarations",
@@ -19,6 +18,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-restricted-import.md",
         },
         fixable: null,
+        messages: {
+            restricted:
+                // eslint-disable-next-line @mysticatea/eslint-plugin/report-message-format
+                "'{{name}}' module is restricted from being used.{{customMessage}}",
+        },
         schema: [
             {
                 type: "array",
@@ -48,11 +52,7 @@ module.exports = {
                 additionalItems: false,
             },
         ],
-        messages: {
-            restricted:
-                // eslint-disable-next-line @mysticatea/eslint-plugin/report-message-format
-                "'{{name}}' module is restricted from being used.{{customMessage}}",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-restricted-require.js
+++ b/lib/rules/no-restricted-require.js
@@ -10,7 +10,6 @@ const visit = require("../util/visit-require")
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "disallow specified modules when loaded by `require`",
             category: "Stylistic Issues",
@@ -19,6 +18,11 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-restricted-require.md",
         },
         fixable: null,
+        messages: {
+            restricted:
+                // eslint-disable-next-line @mysticatea/eslint-plugin/report-message-format
+                "'{{name}}' module is restricted from being used.{{customMessage}}",
+        },
         schema: [
             {
                 type: "array",
@@ -48,11 +52,7 @@ module.exports = {
                 additionalItems: false,
             },
         ],
-        messages: {
-            restricted:
-                // eslint-disable-next-line @mysticatea/eslint-plugin/report-message-format
-                "'{{name}}' module is restricted from being used.{{customMessage}}",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -6,7 +6,6 @@
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description: "disallow synchronous methods",
             category: "Stylistic Issues",
@@ -15,6 +14,9 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-sync.md",
         },
         fixable: null,
+        messages: {
+            noSync: "Unexpected sync method: '{{propertyName}}'.",
+        },
         schema: [
             {
                 type: "object",
@@ -27,9 +29,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
-        messages: {
-            noSync: "Unexpected sync method: '{{propertyName}}'.",
-        },
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/no-unpublished-bin.js
+++ b/lib/rules/no-unpublished-bin.js
@@ -38,7 +38,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unpublished-bin.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -49,6 +48,7 @@ module.exports = {
                 },
             },
         ],
+        type: "problem",
     },
     create(context) {
         return {

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -21,7 +21,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unpublished-import.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -35,6 +34,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-unpublished-require.js
+++ b/lib/rules/no-unpublished-require.js
@@ -21,7 +21,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unpublished-require.md",
         },
-        type: "problem",
         fixable: null,
         schema: [
             {
@@ -35,6 +34,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const filePath = context.getFilename()

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -1041,6 +1041,7 @@ function hasPattern(s, pattern) {
 
 module.exports = {
     meta: {
+        deprecated: true,
         docs: {
             description:
                 "disallow unsupported ECMAScript features on the specified version",
@@ -1053,8 +1054,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unsupported-features.md",
         },
-        type: "problem",
-        deprecated: true,
         fixable: null,
         schema: [
             {
@@ -1076,6 +1075,7 @@ module.exports = {
                 ],
             },
         ],
+        type: "problem",
     },
     create(context) {
         const sourceCode = context.getSourceCode()

--- a/lib/rules/no-unsupported-features/es-builtins.js
+++ b/lib/rules/no-unsupported-features/es-builtins.js
@@ -144,8 +144,11 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unsupported-features/es-builtins.md",
         },
-        type: "problem",
         fixable: null,
+        messages: {
+            unsupported:
+                "The '{{name}}' is not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+        },
         schema: [
             {
                 type: "object",
@@ -166,10 +169,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
-        messages: {
-            unsupported:
-                "The '{{name}}' is not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
-        },
+        type: "problem",
     },
     create(context) {
         return {

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -523,26 +523,7 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unsupported-features/es-syntax.md",
         },
-        type: "problem",
         fixable: null,
-        schema: [
-            {
-                type: "object",
-                properties: {
-                    version: {
-                        type: "string",
-                    },
-                    ignores: {
-                        type: "array",
-                        items: {
-                            enum: Object.keys(features),
-                        },
-                        uniqueItems: true,
-                    },
-                },
-                additionalProperties: false,
-            },
-        ],
         messages: {
             //------------------------------------------------------------------
             // ES2015
@@ -652,6 +633,25 @@ module.exports = {
             "no-nullish-coalescing-operators":
                 "Nullish coalescing operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
         },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    version: {
+                        type: "string",
+                    },
+                    ignores: {
+                        type: "array",
+                        items: {
+                            enum: Object.keys(features),
+                        },
+                        uniqueItems: true,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        type: "problem",
     },
     create(context) {
         return defineVisitor(context, parseOptions(context))

--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -377,8 +377,11 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-unsupported-features/node-builtins.md",
         },
-        type: "problem",
         fixable: null,
+        messages: {
+            unsupported:
+                "The '{{name}}' is not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+        },
         schema: [
             {
                 type: "object",
@@ -402,10 +405,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
-        messages: {
-            unsupported:
-                "The '{{name}}' is not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
-        },
+        type: "problem",
     },
     create(context) {
         return {

--- a/lib/rules/prefer-global/buffer.js
+++ b/lib/rules/prefer-global/buffer.js
@@ -28,15 +28,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/buffer.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"buffer\").Buffer'. Use the global variable 'Buffer' instead.",
             preferModule:
                 "Unexpected use of the global variable 'Buffer'. Use 'require(\"buffer\").Buffer' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/console.js
+++ b/lib/rules/prefer-global/console.js
@@ -25,15 +25,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/console.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"console\")'. Use the global variable 'console' instead.",
             preferModule:
                 "Unexpected use of the global variable 'console'. Use 'require(\"console\")' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/process.js
+++ b/lib/rules/prefer-global/process.js
@@ -25,15 +25,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/process.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"process\")'. Use the global variable 'process' instead.",
             preferModule:
                 "Unexpected use of the global variable 'process'. Use 'require(\"process\")' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/text-decoder.js
+++ b/lib/rules/prefer-global/text-decoder.js
@@ -28,15 +28,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/text-decoder.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"util\").TextDecoder'. Use the global variable 'TextDecoder' instead.",
             preferModule:
                 "Unexpected use of the global variable 'TextDecoder'. Use 'require(\"util\").TextDecoder' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/text-encoder.js
+++ b/lib/rules/prefer-global/text-encoder.js
@@ -28,15 +28,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/text-encoder.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"util\").TextEncoder'. Use the global variable 'TextEncoder' instead.",
             preferModule:
                 "Unexpected use of the global variable 'TextEncoder'. Use 'require(\"util\").TextEncoder' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/url-search-params.js
+++ b/lib/rules/prefer-global/url-search-params.js
@@ -28,15 +28,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/url-search-params.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"url\").URLSearchParams'. Use the global variable 'URLSearchParams' instead.",
             preferModule:
                 "Unexpected use of the global variable 'URLSearchParams'. Use 'require(\"url\").URLSearchParams' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/prefer-global/url.js
+++ b/lib/rules/prefer-global/url.js
@@ -27,15 +27,15 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/prefer-global/url.md",
         },
-        type: "suggestion",
         fixable: null,
-        schema: [{ enum: ["always", "never"] }],
         messages: {
             preferGlobal:
                 "Unexpected use of 'require(\"url\").URL'. Use the global variable 'URL' instead.",
             preferModule:
                 "Unexpected use of the global variable 'URL'. Use 'require(\"url\").URL' instead.",
         },
+        schema: [{ enum: ["always", "never"] }],
+        type: "suggestion",
     },
 
     create(context) {

--- a/lib/rules/process-exit-as-throw.js
+++ b/lib/rules/process-exit-as-throw.js
@@ -153,9 +153,9 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/process-exit-as-throw.md",
         },
-        type: "problem",
         fixable: null,
         schema: [],
+        type: "problem",
         supported: CodePathAnalyzer != null,
     },
     create() {

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -75,7 +75,6 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/shebang.md",
         },
-        type: "problem",
         fixable: "code",
         schema: [
             {
@@ -87,6 +86,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "problem",
     },
     create(context) {
         const sourceCode = context.getSourceCode()

--- a/lib/util/visit-import.js
+++ b/lib/util/visit-import.js
@@ -25,7 +25,7 @@ const stripImportPathParams = require("./strip-import-path-params")
  */
 module.exports = function visitImport(
     context,
-    { includeCore = false, optionIndex = 0 } = {},
+    { includeCore = false, optionIndex = 0 },
     callback
 ) {
     const targets = []

--- a/lib/util/visit-require.js
+++ b/lib/util/visit-require.js
@@ -25,7 +25,7 @@ const stripImportPathParams = require("./strip-import-path-params")
  */
 module.exports = function visitRequire(
     context,
-    { includeCore = false } = {},
+    { includeCore = false },
     callback
 ) {
     const targets = []

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "11.1.0",
   "description": "Additional ESLint's rules for Node.js",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
   },
   "main": "lib/index.js",
   "files": [
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "eslint-plugin-es": "^4.1.0",
-    "eslint-utils": "^2.1.0",
+    "eslint-utils": "^3.0.0",
     "ignore": "^5.1.1",
     "is-core-module": "^2.3.0",
     "minimatch": "^3.0.4",
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.3.0",
-    "eslint": "^7.9.0",
+    "eslint": "^7.26.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "eslint-plugin-es": "^4.1.0",
-    "eslint-utils": "^2.0.0",
+    "eslint-utils": "^2.1.0",
     "ignore": "^5.1.1",
     "is-core-module": "^2.3.0",
     "minimatch": "^3.0.4",
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.3.0",
-    "eslint": "^7.2.0",
+    "eslint": "^7.9.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "11.1.0",
   "description": "Additional ESLint's rules for Node.js",
   "engines": {
-    "node": "^10.12.0 || >=12.0.0"
+    "node": ">=8.10.0"
   },
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "11.1.0",
   "description": "Additional ESLint's rules for Node.js",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^10.12.0 || >=12.0.0"
   },
   "main": "lib/index.js",
   "files": [
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^10.0.3",
     "codecov": "^3.3.0",
-    "eslint": "^6.3.0",
+    "eslint": "^7.0.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.3.0",
-    "eslint": "^7.26.0",
+    "eslint": "^7.32.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "semver": "^6.1.0"
   },
   "devDependencies": {
-    "@mysticatea/eslint-plugin": "^10.0.3",
+    "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.3.0",
-    "eslint": "^7.0.0",
+    "eslint": "^7.2.0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "11.1.0",
   "description": "Additional ESLint's rules for Node.js",
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "main": "lib/index.js",
   "files": [
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.3.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.0.0-0",
     "eslint-plugin-node": "file:.",
     "fast-glob": "^2.2.6",
     "globals": "^11.12.0",

--- a/scripts/update-lib-index.js
+++ b/scripts/update-lib-index.js
@@ -6,7 +6,7 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
+const { ESLint } = require("eslint")
 const { rules } = require("./rules")
 
 const filePath = path.resolve(__dirname, "../lib/index.js")
@@ -35,8 +35,8 @@ module.exports = {
     },
 }
 `
-const engine = new CLIEngine({ fix: true })
-const lintResult = engine.executeOnText(rawContent, filePath)
+const engine = new ESLint({ fix: true })
+const lintResult = engine.lintText(rawContent, { filePath })
 const content = lintResult.results[0].output || rawContent
 
 fs.writeFileSync(filePath, content)

--- a/tests/lib/configs/recommended.js
+++ b/tests/lib/configs/recommended.js
@@ -7,13 +7,13 @@ const originalCwd = process.cwd()
 
 describe("node/recommended config", () => {
     describe("in CJS directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/cjs/")
+        const CJSRoot = path.resolve(__dirname, "../../fixtures/configs/cjs/")
 
         /** @type {CLIEngine} */
         let engine = null
 
         beforeEach(() => {
-            process.chdir(root)
+            process.chdir(CJSRoot)
             engine = new CLIEngine({
                 baseConfig: { extends: "plugin:node/recommended" },
                 useEslintrc: false,
@@ -27,7 +27,7 @@ describe("node/recommended config", () => {
         it("*.js files should be a script.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.js")
+                path.join(CJSRoot, "test.js")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -46,7 +46,7 @@ describe("node/recommended config", () => {
         it("*.cjs files should be a script.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.cjs")
+                path.join(CJSRoot, "test.cjs")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -65,7 +65,7 @@ describe("node/recommended config", () => {
         it("*.mjs files should be a module.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.mjs")
+                path.join(CJSRoot, "test.mjs")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -84,13 +84,13 @@ describe("node/recommended config", () => {
     })
 
     describe("in ESM directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/esm/")
+        const ESMRoot = path.resolve(__dirname, "../../fixtures/configs/esm/")
 
         /** @type {CLIEngine} */
         let engine = null
 
         beforeEach(() => {
-            process.chdir(root)
+            process.chdir(ESMRoot)
             engine = new CLIEngine({
                 baseConfig: { extends: "plugin:node/recommended" },
                 useEslintrc: false,
@@ -104,7 +104,7 @@ describe("node/recommended config", () => {
         it("*.js files should be a module.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.js")
+                path.join(ESMRoot, "test.js")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -124,7 +124,7 @@ describe("node/recommended config", () => {
         it("*.cjs files should be a script.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.cjs")
+                path.join(ESMRoot, "test.cjs")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -143,7 +143,7 @@ describe("node/recommended config", () => {
         it("*.mjs files should be a module.", () => {
             const report = engine.executeOnText(
                 "import 'foo'",
-                path.join(root, "test.mjs")
+                path.join(ESMRoot, "test.mjs")
             )
 
             assert.deepStrictEqual(report.results[0].messages, [

--- a/tests/lib/configs/recommended.js
+++ b/tests/lib/configs/recommended.js
@@ -2,19 +2,19 @@
 
 const assert = require("assert")
 const path = require("path")
-const { CLIEngine } = require("eslint")
+const { ESLint } = require("eslint")
 const originalCwd = process.cwd()
 
 describe("node/recommended config", () => {
     describe("in CJS directory", () => {
         const CJSRoot = path.resolve(__dirname, "../../fixtures/configs/cjs/")
 
-        /** @type {CLIEngine} */
+        /** @type {ESLint} */
         let engine = null
 
         beforeEach(() => {
             process.chdir(CJSRoot)
-            engine = new CLIEngine({
+            engine = new ESLint({
                 baseConfig: { extends: "plugin:node/recommended" },
                 useEslintrc: false,
             })
@@ -25,9 +25,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.js files should be a script.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(CJSRoot, "test.js")
+                { filePath: path.join(CJSRoot, "test.js") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -44,9 +44,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.cjs files should be a script.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(CJSRoot, "test.cjs")
+                { filePath: path.join(CJSRoot, "test.cjs") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -63,9 +63,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.mjs files should be a module.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(CJSRoot, "test.mjs")
+                { filePath: path.join(CJSRoot, "test.mjs") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -86,12 +86,12 @@ describe("node/recommended config", () => {
     describe("in ESM directory", () => {
         const ESMRoot = path.resolve(__dirname, "../../fixtures/configs/esm/")
 
-        /** @type {CLIEngine} */
+        /** @type {ESLint} */
         let engine = null
 
         beforeEach(() => {
             process.chdir(ESMRoot)
-            engine = new CLIEngine({
+            engine = new ESLint({
                 baseConfig: { extends: "plugin:node/recommended" },
                 useEslintrc: false,
             })
@@ -102,9 +102,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.js files should be a module.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(ESMRoot, "test.js")
+                { filePath: path.join(ESMRoot, "test.js") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -122,9 +122,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.cjs files should be a script.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(ESMRoot, "test.cjs")
+                { filePath: path.join(ESMRoot, "test.cjs") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [
@@ -141,9 +141,9 @@ describe("node/recommended config", () => {
         })
 
         it("*.mjs files should be a module.", () => {
-            const report = engine.executeOnText(
+            const report = engine.lintText(
                 "import 'foo'",
-                path.join(ESMRoot, "test.mjs")
+                { filePath: path.join(ESMRoot, "test.mjs") }
             )
 
             assert.deepStrictEqual(report.results[0].messages, [

--- a/tests/lib/rules/callback-return.js
+++ b/tests/lib/rules/callback-return.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/callback-return")
 
 new RuleTester().run("callback-return", rule, {

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/exports-style")
 
 new RuleTester().run("exports-style", rule, {

--- a/tests/lib/rules/global-require.js
+++ b/tests/lib/rules/global-require.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/global-require")
 
 const ERROR = { messageId: "unexpected", type: "CallExpression" }

--- a/tests/lib/rules/handle-callback-err.js
+++ b/tests/lib/rules/handle-callback-err.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/handle-callback-err")
 
 const EXPECTED_DECL_ERROR = {

--- a/tests/lib/rules/no-callback-literal.js
+++ b/tests/lib/rules/no-callback-literal.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-callback-literal")
 
 const ruleTester = new RuleTester()

--- a/tests/lib/rules/no-extraneous-require.js
+++ b/tests/lib/rules/no-extraneous-require.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-extraneous-require")
 
 /**

--- a/tests/lib/rules/no-hide-core-modules.js
+++ b/tests/lib/rules/no-hide-core-modules.js
@@ -14,7 +14,7 @@
 //------------------------------------------------------------------------------
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-hide-core-modules")
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-missing-require")
 
 /**

--- a/tests/lib/rules/no-mixed-requires.js
+++ b/tests/lib/rules/no-mixed-requires.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-mixed-requires")
 
 new RuleTester().run("no-mixed-requires", rule, {

--- a/tests/lib/rules/no-new-require.js
+++ b/tests/lib/rules/no-new-require.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-new-require")
 
 new RuleTester().run("no-new-require", rule, {

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -7,7 +7,7 @@
 /*eslint-disable no-template-curly-in-string */
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-path-concat")
 
 new RuleTester({

--- a/tests/lib/rules/no-process-env.js
+++ b/tests/lib/rules/no-process-env.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-process-env")
 
 new RuleTester().run("no-process-env", rule, {

--- a/tests/lib/rules/no-process-exit.js
+++ b/tests/lib/rules/no-process-exit.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-process-exit")
 
 new RuleTester().run("no-process-exit", rule, {

--- a/tests/lib/rules/no-restricted-require.js
+++ b/tests/lib/rules/no-restricted-require.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-restricted-require")
 
 new RuleTester({

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-sync")
 
 new RuleTester().run("no-sync", rule, {

--- a/tests/lib/rules/no-unpublished-bin.js
+++ b/tests/lib/rules/no-unpublished-bin.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unpublished-bin")
 
 /**

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unpublished-require")
 
 /**

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unsupported-features")
 
 const VERSION_MAP = new Map([

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -81,9 +81,7 @@ function convertPattern(retv, pattern) {
             ;[].push.apply(
                 retv.valid,
                 pattern.keys.map(key => ({
-                    code: `/*${
-                        pattern.name
-                    }: ${versionText}, ignores: ["${key}"]*/ ${pattern.code}`,
+                    code: `/*${pattern.name}: ${versionText}, ignores: ["${key}"]*/ ${pattern.code}`,
                     env: { es6: true },
                     globals: { SharedArrayBuffer: false, Atomics: false },
                     options: [{ version, ignores: [key] }],

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/no-unsupported-features/node-builtins")
 
 /**

--- a/tests/lib/rules/prefer-global/buffer.js
+++ b/tests/lib/rules/prefer-global/buffer.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/buffer")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/console.js
+++ b/tests/lib/rules/prefer-global/console.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/console")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/process.js
+++ b/tests/lib/rules/prefer-global/process.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/process")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/text-decoder.js
+++ b/tests/lib/rules/prefer-global/text-decoder.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/text-decoder")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/text-encoder.js
+++ b/tests/lib/rules/prefer-global/text-encoder.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/text-encoder")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/url-search-params.js
+++ b/tests/lib/rules/prefer-global/url-search-params.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/url-search-params")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-global/url.js
+++ b/tests/lib/rules/prefer-global/url.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-global/url")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-promises/dns.js
+++ b/tests/lib/rules/prefer-promises/dns.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-promises/dns")
 
 new RuleTester({

--- a/tests/lib/rules/prefer-promises/fs.js
+++ b/tests/lib/rules/prefer-promises/fs.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../../lib/rules/prefer-promises/fs")
 
 new RuleTester({

--- a/tests/lib/rules/shebang.js
+++ b/tests/lib/rules/shebang.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/shebang")
 
 /**


### PR DESCRIPTION
ESLint has [released](https://eslint.org/blog/2021/08/eslint-v8.0.0-beta.0-released) the first beta version of v8 🎉

(dev)Dependencies should be compatible with ESLint 8 too before we can merge this one:

- [ ] [`eslint-plugin-es`](https://github.com/mysticatea/eslint-plugin-es)
  - [ ] PR
  - [ ] Release
- [ ] [`eslint-utils`](https://github.com/mysticatea/eslint-utils)
  - [ ] PR
  - [ ] Release
- [ ] [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin) (https://github.com/mysticatea/eslint-plugin/issues/31)
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/29
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/32
  - [ ] Release

---

BREAKING CHANGE: Requires Node@^12.22.0 || ^14.17.0 || >=16.0.0
BREAKING CHANGE: Requires ESLint@^8.x

Closes #294

This branch is dependent on #224