### PR TITLE
fix: support typecasted requires

### DIFF
--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -13,6 +13,8 @@ const ACCEPTABLE_PARENTS = [
     "ConditionalExpression",
     "Program",
     "VariableDeclaration",
+    "TSAsExpression",
+    "TSTypeAssertion",
 ]
 
 /**


### PR DESCRIPTION
This fixes a false positive when typecasting a global require in typescript, like so:

```
const wcwidth = require('wcwidth') as (str: string) => number;
```

Happy to add tests if you're happy having `@typescript-eslint/parser` as a dev dependency :)