### PR TITLE
no-process-env: support custom error message "use the env wrapper"

### DIFF
--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -7,6 +7,23 @@ The `process.env` object in Node.js is used to store deployment/configuration pa
 
 This rule is aimed at discouraging use of `process.env` to avoid global dependencies. As such, it will warn whenever `process.env` is used.
 
+### Options
+
+You can customize the error message for this rule:
+
+```json
+{
+  "rules": {
+    "node/no-process-env": [
+      "error",
+      {
+        "customMessage": "Use the env wrapper instead."
+      }
+    ]
+  }
+}
+```
+
 Examples of **incorrect** code for this rule:
 
 ```js

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -19,13 +19,25 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-process-env.md",
         },
         fixable: null,
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    customMessage: {
+                        type: "string",
+                    },
+                },
+            },
+        ],
         messages: {
             unexpectedProcessEnv: "Unexpected use of process.env.",
         },
     },
 
     create(context) {
+        const options = context.options[0] || {}
+        const customMessage = options.customMessage
+
         return {
             MemberExpression(node) {
                 const objectName = node.object.name
@@ -37,7 +49,13 @@ module.exports = {
                     propertyName &&
                     propertyName === "env"
                 ) {
-                    context.report({ node, messageId: "unexpectedProcessEnv" })
+                    const report = { node }
+                    if (customMessage) {
+                        report.message = customMessage
+                    } else {
+                        report.messageId = "unexpectedProcessEnv"
+                    }
+                    context.report(report)
                 }
             },
         }

--- a/tests/lib/rules/no-process-env.js
+++ b/tests/lib/rules/no-process-env.js
@@ -43,5 +43,20 @@ new RuleTester().run("no-process-env", rule, {
                 },
             ],
         },
+        {
+            code: "f(process.env)",
+            options: [
+                {
+                    customMessage:
+                        "custom error message - use the wrapper instead",
+                },
+            ],
+            errors: [
+                {
+                    message: "custom error message - use the wrapper instead",
+                    type: "MemberExpression",
+                },
+            ],
+        },
     ],
 })


### PR DESCRIPTION
This is the first time I've ever touched eslint rule stuff, but I feel pretty good about this change, and was able to maintain the 100% test coverage on this rule.

