### PR TITLE
Fix grammar in deprecation message

### DIFF
--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -741,7 +741,7 @@ module.exports = {
                 node,
                 loc: node.loc,
                 message:
-                    "{{name}} was deprecated since v{{version}}{{replace}}.",
+                    "{{name}} has been deprecated since v{{version}}{{replace}}.",
                 data: {
                     name,
                     version: info.since,


### PR DESCRIPTION
Should be either "X was deprecated in Y", or "X has been deprecated since Y", but not "was...since"