### PR TITLE
💥  Update node/no-unsupported-features/node-builtins with crypto.randomUUID

### DIFF
--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -102,6 +102,7 @@ const trackMap = {
             randomFill: {
                 [READ]: { supported: "7.10.0", backported: ["6.13.0"] },
             },
+            randomUUID: { [READ]: { supported: "14.17.0" } },
             scrypt: { [READ]: { supported: "10.5.0" } },
             scryptSync: { [READ]: { supported: "10.5.0" } },
             setFips: { [READ]: { supported: "10.0.0" } },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -1887,6 +1887,10 @@ new RuleTester({
                     options: [{ version: "7.10.0" }],
                 },
                 {
+                    code: "require('crypto').randomUUID",
+                    options: [{ version: "14.17.0" }],
+                },
+                {
                     code: "require('crypto').scrypt",
                     options: [{ version: "10.5.0" }],
                 },
@@ -2271,6 +2275,20 @@ new RuleTester({
                                 name: "crypto.randomFill",
                                 supported: "7.10.0 (backported: ^6.13.0)",
                                 version: "7.9.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "require('crypto').randomUUID",
+                    options: [{ version: "14.16.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "crypto.randomUUID",
+                                supported: "14.17.0",
+                                version: "14.16.0",
                             },
                         },
                     ],


### PR DESCRIPTION
This commit adds support for the crypto.randomUUID method, which was added to the standard lib in v14.17.0.

https://nodejs.org/docs/latest-v14.x/api/crypto.html#crypto_crypto_randomuuid_options