### PR TITLE
Add "node" to list of plugin in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ $ npm install --save-dev eslint eslint-plugin-node
         "node/prefer-global/url": ["error", "always"],
         "node/prefer-promises/dns": "error",
         "node/prefer-promises/fs": "error"
-    }
+    },
+    "plugins": {
+        "node"
+    }    
 }
 ```
 


### PR DESCRIPTION
The example is not quite complete as it doesn't mention that "node" should be added to the list of plugins (which I always forget to do).