### PR TITLE
bump minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-utils": "^2.0.0",
     "ignore": "^5.1.1",
     "is-core-module": "^2.3.0",
-    "minimatch": "^3.0.4",
+    "minimatch": "^3.0.5",
     "resolve": "^1.10.1",
     "semver": "^6.1.0"
   },


### PR DESCRIPTION
"A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service."
Affected versions: < 3.0.5